### PR TITLE
source: docs-github-copilot-cca-validation-parallel (#105)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -215,6 +215,18 @@
       "file": "source-notes/blog-simonwillison-zig-anti-ai.md",
       "confidence_overall": "emerging",
       "status": "current"
+    },
+    "docs-github-copilot-cca-validation-parallel": {
+      "slug": "docs-github-copilot-cca-validation-parallel",
+      "title": "Copilot cloud agent's validation tools are now 20% faster",
+      "source_url": "https://github.blog/changelog/2026-04-10-copilot-cloud-agents-validation-tools-are-now-20-faster",
+      "source_type": "docs",
+      "author": "GitHub (official changelog)",
+      "date_extracted": "2026-05-10",
+      "issue": "#105",
+      "file": "source-notes/docs-github-copilot-cca-validation-parallel.md",
+      "confidence_overall": "anecdotal",
+      "status": "current"
     }
   },
   "last_updated": "2026-05-10"

--- a/source-notes/docs-github-copilot-cca-validation-parallel.md
+++ b/source-notes/docs-github-copilot-cca-validation-parallel.md
@@ -1,0 +1,248 @@
+---
+source_url: https://github.blog/changelog/2026-04-10-copilot-cloud-agents-validation-tools-are-now-20-faster
+source_type: docs
+title: "Copilot cloud agent's validation tools are now 20% faster"
+author: GitHub (official changelog)
+date_published: 2026-04-10
+date_extracted: 2026-05-10
+last_checked: 2026-05-10
+status: current
+confidence_overall: anecdotal
+issue: "#105"
+---
+
+# Copilot Cloud Agent Validation Tools: Parallel Execution (GitHub Changelog)
+
+> GitHub's official announcement that Copilot cloud agent's four built-in validation
+> tools (CodeQL, GitHub Advisory Database, secret scanning, Copilot code review) now
+> run in parallel rather than sequentially, yielding a vendor-reported 20% reduction
+> in validation time; the source is thin — a single metric without methodology,
+> baseline, or operational context — but documents the existence of an automatic
+> safety-scanning layer in the Copilot cloud agent that self-remediates before
+> requesting human review.
+
+## Source Context
+
+- **Type**: docs (GitHub official product changelog, ~300 words, April 10, 2026)
+- **Author credibility**: GitHub engineering team announcing a production infrastructure
+  improvement. Authoritative for the fact that the four tools exist, that they now run
+  in parallel, and that this is the architecture of Copilot cloud agent validation.
+  Not a credible source for the 20% figure itself — no methodology, baseline measurement
+  period, or workload characterization is provided. The quality-preservation claim
+  ("same quality maintained") is unsubstantiated.
+- **Scope**: The Copilot cloud agent's built-in validation toolchain — what tools run,
+  that they now run in parallel, and that users can configure which tools are enabled.
+  Does NOT cover: how effective each tool is at catching issues in AI-generated code,
+  whether the auto-remediation actually resolves flagged findings or just produces
+  fix attempts, what percentage of Copilot-written code triggers one or more tool
+  findings, latency or cost data before/after the parallelization, or how this layer
+  interacts with repository-level CI pipelines.
+
+## Extracted Claims
+
+### Claim 1: Copilot cloud agent's validation tools now run in parallel rather than sequentially, reducing validation time by 20%
+
+- **Evidence**: Official GitHub product changelog announcing the architectural change as
+  shipped. The 20% figure is stated without methodology or baseline.
+- **Confidence**: anecdotal (vendor-reported single metric; no independent verification,
+  no workload characterization, no confidence interval)
+- **Quote**: "These validation tools now run in parallel rather than sequentially,
+  reducing validation time by 20%."
+- **Our assessment**: The parallelization is a platform-side infrastructure change that
+  harness engineers cannot tune or control — it applies automatically to all Copilot
+  cloud agent runs. The 20% figure should be treated as an order-of-magnitude signal
+  (meaningful speedup achieved) rather than a precise benchmark. For Ch02 (Harness
+  Engineering): this is a platform capability fact, not a workflow design pattern. Teams
+  using Copilot cloud agents should note that validation is no longer a sequential
+  bottleneck — it now runs concurrently with (or immediately after) code generation
+  rather than extending the total agent cycle time by the sum of each tool's latency.
+
+### Claim 2: The Copilot cloud agent validation toolchain covers four distinct scanning domains: static analysis (CodeQL), dependency risk (GitHub Advisory Database), credential hygiene (secret scanning), and AI-assisted review (Copilot code review)
+
+- **Evidence**: Explicit enumeration in the changelog entry.
+- **Confidence**: settled (definitional; first-party product documentation listing the
+  tools by name)
+- **Quote**: (no contiguous quote captures the full list; see Extraction Notes)
+- **Our assessment**: The four-tool stack covers a standard defense-in-depth approach
+  for AI-generated code: vulnerabilities in the code itself (CodeQL), vulnerabilities
+  introduced by dependencies (Advisory DB), accidental credential exposure (secret
+  scanning), and a second-pass review by a different AI system (Copilot code review).
+  For Ch03 (Safety and Verification): teams using Copilot cloud agents receive
+  this validation layer automatically — they do not need to configure external CI scans
+  to get coverage across these four dimensions for agent-written code. The four tools
+  are complementary; they address distinct risk classes rather than redundant checks.
+
+### Claim 3: The validation tools automatically scan Copilot-written code and attempt to self-remediate identified issues before requesting human review
+
+- **Evidence**: Feature behavior described in the changelog entry.
+- **Confidence**: emerging (first-party claim about intended behavior; no evidence about
+  remediation success rates or the cases where self-remediation fails and the issue is
+  escalated)
+- **Quote**: (no direct quote; see Extraction Notes)
+- **Our assessment**: The self-remediation loop — scan → fix → re-validate → submit for
+  review — is architecturally significant. It means the Copilot cloud agent operates a
+  built-in verification-and-correction cycle before human review is triggered. This
+  parallels the "automated fix attempts" pattern in `docs-github-copilot-cca-custom-properties.md`'s
+  discussion of CCA capabilities. The quality of self-remediation attempts is unstated;
+  it is possible the agent produces fix attempts that pass the scanner but do not
+  actually resolve the underlying issue. For Ch03: document this as a platform-native
+  verification loop, distinct from test-driven verification — it catches security and
+  quality issues post-generation, not pre-generation.
+
+### Claim 4: Users can configure which of the four validation tools run for a repository via the Copilot → Cloud agent section in repository settings
+
+- **Evidence**: Configuration guidance from the changelog.
+- **Confidence**: settled (product fact; the setting is documented and actionable)
+- **Quote**: (no direct quote; see Extraction Notes)
+- **Our assessment**: Per-tool configurability means teams can opt out of individual
+  validation tools. This is primarily relevant for teams where one of the four tools
+  generates excessive false positives for agent-written code, slowing the pipeline
+  without adding signal. However, disabling validation tools weakens the safety layer.
+  For Ch02 (Harness Engineering): treat validation tool configuration as a governance
+  decision, not a performance tuning knob — disabling CodeQL or secret scanning for
+  agent-written code should require an explicit justification and be tracked as a
+  security tradeoff.
+
+### Claim 5: The 20% speedup preserves validation quality — GitHub asserts the same quality of scanning is maintained
+
+- **Evidence**: Vendor assertion from the changelog.
+- **Confidence**: anecdotal (unsubstantiated vendor claim; no evidence provided that
+  parallel execution does not change scan results, miss conditions that sequential
+  execution caught, or produce different findings due to ordering effects)
+- **Quote**: "Copilot works faster while still maintaining the same quality"
+- **Our assessment**: This claim should be accepted provisionally as a vendor assurance
+  rather than a verified empirical result. For security-sensitive use cases, teams should
+  not assume quality equivalence without their own baseline comparison. The claim is
+  plausible — parallel execution of independent scanners should produce the same findings
+  as sequential execution — but "parallel" does not necessarily mean fully independent if
+  scanners share any state or depend on shared artifact caches. Accept provisionally;
+  reject if later evidence shows finding discrepancies between runs.
+
+## Concrete Artifacts
+
+### Validation Toolchain Summary (synthesized from changelog)
+
+```
+Copilot Cloud Agent — Built-in Validation Tools
+
+Tool                          | Domain                | Runs in
+------------------------------+-----------------------+--------------------
+CodeQL                        | Static analysis (SAST)| Parallel (after Apr 10, 2026)
+GitHub Advisory Database      | Dependency risk       | Parallel
+Secret scanning               | Credential exposure   | Parallel
+Copilot code review           | AI-assisted review    | Parallel
+
+Behavior:
+  1. Copilot writes code
+  2. All four validation tools scan concurrently
+  3. Agent attempts to self-remediate any findings
+  4. Agent requests human review only after validation passes
+
+Configuration:
+  Repository Settings → Copilot → Cloud agent → select which tools run
+
+Performance improvement:
+  20% reduction in validation time (vendor-reported, Apr 2026)
+  Prior architecture: sequential execution (each tool waits for previous)
+  New architecture: parallel execution (all tools run concurrently)
+```
+
+## Cross-References
+
+- **Corroborates**:
+  - `docs-github-copilot-cca-custom-properties.md` (Claim 7 — pilot-first adoption
+    pattern): That source documents how enterprise admins enable Copilot cloud agent
+    (CCA) progressively; this source documents a platform infrastructure improvement
+    to the same CCA. Both are part of the same CCA capability surface. The parallelized
+    validation layer makes the CCA more efficient, which is consistent with GitHub's
+    framing of CCA as production-ready.
+  - `docs-ghaw-agent-factory-status.md` (Claim 1 — factory runs 183+ workflows with
+    Copilot as primary engine at 65%): The GitHub Next production factory relies heavily
+    on the Copilot engine. The validation toolchain speedup benefits any Copilot-engine
+    workflow that uses CCA, including the factory's high-volume scheduled workflows. No
+    specific factory workflow is identified as a beneficiary, but the factory's scale
+    (65% of 183+ workflows) makes the aggregate speedup non-trivial.
+  - `docs-github-copilot-pr-review-metrics.md` (overall type and scope): That source
+    is another GitHub changelog entry from approximately the same period (April 2026)
+    documenting a Copilot capability update (PR review metrics in the usage API). Both
+    are thin, vendor-origin changelog entries establishing platform-level facts about
+    Copilot infrastructure. Neither provides empirical evidence of impact.
+
+- **Extends**:
+  - `docs-github-copilot-cca-custom-properties.md`: That source covers CCA governance
+    (enterprise enablement, org-level policies). This source covers CCA runtime
+    performance (validation toolchain). Together they describe two dimensions of the
+    CCA: how it is governed and how fast its safety layer operates. Neither source
+    covers CCA's task capabilities (what it actually does to codebases).
+  - `docs-github-copilot-agent-model-selection.md`: That source covers model selection
+    for CCA (Sonnet vs. Opus tiers). This source covers the validation layer that runs
+    on CCA output. Together they describe CCA's two tunable parameters: what model
+    generates the code, and (partially) which tools scan the output.
+
+- **Contradicts**: None found. No existing source note claims Copilot cloud agent
+  validation runs sequentially, is slow, or has a different tool composition.
+
+- **Novel**:
+  - **Parallel validation as a platform-side optimization primitive**: No existing corpus
+    note documents the architecture of Copilot cloud agent's validation toolchain or
+    the shift from sequential to parallel execution. This is the first description of
+    the four-tool validation stack and its execution model.
+  - **Self-remediation loop before human review**: The pattern of scan → auto-fix →
+    re-validate → submit is not documented in any existing source note. This is the first
+    corpus entry describing a platform-native verification-and-correction cycle for
+    AI-generated code prior to human review.
+
+## Guide Impact
+
+- **Chapter 02 (Harness Engineering)**:
+  - Add a note that Copilot cloud agent includes a built-in four-tool validation layer
+    (CodeQL, Advisory DB, secret scanning, Copilot code review) that runs automatically
+    — teams using CCA do not need to configure external CI scans to achieve baseline
+    security coverage for agent-generated code.
+  - Treat per-tool configuration (which validation tools run) as a governance decision
+    requiring explicit justification, not a performance tuning knob. Disabling any of
+    the four tools weakens the safety layer without guidance on acceptable tradeoffs.
+
+- **Chapter 03 (Safety and Verification)**:
+  - Add the Copilot cloud agent validation loop (scan → auto-fix → re-validate → submit)
+    as a concrete example of a platform-native verification-and-correction cycle. This
+    is architecturally distinct from CI pipeline checks (external, post-merge gate) and
+    from human code review (manual, post-submission). Position it as a "built-in
+    pre-review safety pass" that reduces the burden on human reviewers for the most
+    common security and quality issues.
+  - Note the four-tool coverage dimensions (SAST, dependency risk, credential hygiene,
+    AI-assisted review) as the standard defense-in-depth approach for AI-generated code
+    at the platform level.
+
+## Extraction Notes
+
+1. **Thin source**: The changelog entry is approximately 300 words. The Prospector's
+   triage assessment ("thin evidence — a single metric without operational context")
+   accurately characterizes the source. Claims were exhausted in 5 items; going deeper
+   would require speculation beyond what the source states.
+
+2. **Quote reliability caveat**: WebFetch processes content through an AI model before
+   returning text. The quotes in this note — specifically "These validation tools now run
+   in parallel rather than sequentially, reducing validation time by 20%." and "Copilot
+   works faster while still maintaining the same quality" — were presented by the WebFetch
+   model as direct quotes from the page. Two independent fetches with different prompts
+   returned consistent content, increasing confidence that these reflect the actual page
+   text. However, the Assayer should spot-check these quotes against the live URL before
+   accepting them as verbatim. Claims 2 and 4 do not use quotes because no contiguous
+   verbatim passage capturing those points was returned consistently.
+
+3. **No sub-pages followed**: The changelog entry linked to the Copilot cloud agent
+   documentation page. That linked page was not fetched separately — the changelog itself
+   was the primary source, and its content was fully exhausted in one read. Per MINER.md
+   §1, sub-pages are followed when they are "substantive"; the documentation link is a
+   general product page and would duplicate content covered in `docs-github-copilot-cca-custom-properties.md`.
+
+4. **No contradictions filed**: No claims in this source materially oppose any existing
+   source note at the MINER.md §4a filing threshold. The validation toolchain and parallel
+   execution architecture are novel to the corpus; no prior note made claims that
+   sequential execution is the architecture or that the toolchain has different components.
+
+5. **20% metric is vendor-only**: The 20% reduction figure is unverifiable from this source.
+   It should be treated as directional evidence ("meaningful improvement achieved") not as
+   a calibration constant for planning. No external benchmarks or independent measurements
+   are available for comparison.


### PR DESCRIPTION
Source note extracted by the Miner agent for #105.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.
