### PR TITLE
source: docs-github-copilot-cca-auto-model-selection (#745)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -26,6 +26,19 @@
       "confidence_overall": "anecdotal",
       "status": "current"
     },
+    "docs-github-copilot-cca-auto-model-selection": {
+      "slug": "docs-github-copilot-cca-auto-model-selection",
+      "title": "Copilot cloud agent supports auto model selection",
+      "source_url": "https://github.blog/changelog/2026-05-14-copilot-cloud-agent-supports-auto-model-selection",
+      "source_type": "docs",
+      "author": "GitHub (official changelog)",
+      "date_published": "2026-05-14",
+      "date_extracted": "2026-05-15",
+      "issue": "#745",
+      "file": "source-notes/docs-github-copilot-cca-auto-model-selection.md",
+      "confidence_overall": "anecdotal",
+      "status": "current"
+    },
     "docs-github-copilot-cca-rest-api-tasks": {
       "slug": "docs-github-copilot-cca-rest-api-tasks",
       "title": "Start Copilot cloud agent tasks via the REST API",

--- a/source-notes/docs-github-copilot-cca-auto-model-selection.md
+++ b/source-notes/docs-github-copilot-cca-auto-model-selection.md
@@ -1,0 +1,306 @@
+---
+source_url: https://github.blog/changelog/2026-05-14-copilot-cloud-agent-supports-auto-model-selection
+source_type: docs
+title: "Copilot cloud agent supports auto model selection"
+author: GitHub (official changelog)
+date_published: 2026-05-14
+date_extracted: 2026-05-15
+last_checked: 2026-05-15
+status: current
+confidence_overall: anecdotal
+issue: "#745"
+---
+
+# Copilot Cloud Agent Supports Auto Model Selection
+
+> GitHub's May 2026 announcement that Copilot Cloud Agent (CCA) now supports
+> auto model selection — routing requests to the best available model based on
+> system health and model performance, with a 10% multiplier discount and
+> exemption from weekly rate limits — completing GitHub's auto-routing rollout
+> across all three Copilot surfaces (CLI: April 2026; web-agent manual selection:
+> April 2026; CCA auto: May 2026).
+
+## Source Context
+
+- **Type**: docs (GitHub official product changelog, May 14, 2026, ~100 words)
+- **Author credibility**: GitHub engineering team announcing a production feature.
+  Authoritative for the fact that CCA auto model selection now exists, what billing
+  benefits apply, and the routing criterion summary. Not a credible source for the
+  specific model pool composition, internal routing implementation, or comparative
+  task-quality outcomes between auto and manually pinned models.
+- **Scope**: The introduction of "Auto" as a selectable option in the CCA model
+  picker, with routing driven by system health and model performance, a 10%
+  multiplier discount, and weekly rate-limit exemption. The entry links to the
+  GitHub documentation page for auto model selection
+  (https://docs.github.com/copilot/concepts/auto-model-selection) for additional
+  technical details. Does NOT cover: specific models in the auto pool, granular
+  routing logic, governance admin controls, or behavioral differences from the CLI
+  auto mode announced in April 2026.
+
+## Extracted Claims
+
+### Claim 1: Copilot Cloud Agent now supports auto model selection via an "Auto" option in the model picker
+
+- **Evidence**: Official GitHub product changelog announcing the feature.
+- **Confidence**: settled (product fact — the feature exists and is documented)
+- **Quote**: "Copilot cloud agent now supports Copilot auto model selection."
+- **Our assessment**: This is the third distinct Copilot surface to gain auto/model
+  routing controls: the CLI gained auto model selection in April 2026 (issue #203),
+  the web UI gained manual model selection for Claude/Codex agents in April 2026
+  (issue #171), and now the cloud agent gains its own auto mode. The pattern
+  confirms GitHub is systematically building model-routing primitives across all
+  Copilot entry points. For Ch02: the tooling landscape section should now describe
+  CCA as a surface where model routing is delegatable to the platform, not just a
+  fixed-model environment.
+
+### Claim 2: Auto routing for CCA selects the best available model based on system health and model performance
+
+- **Evidence**: Official changelog states the routing criterion explicitly. The
+  linked documentation (https://docs.github.com/copilot/concepts/auto-model-selection)
+  corroborates: "Copilot auto model selection intelligently chooses models based on
+  real time system health and model performance."
+- **Confidence**: settled (routing criterion stated in official changelog; corroborated
+  by linked documentation)
+- **Quote**: "When you select Auto in the model picker, Copilot intelligently selects
+  the best available model based on system health and model performance."
+- **Our assessment**: The routing heuristic for CCA auto — "system health and model
+  performance" — is substantively different in framing from the CLI auto heuristic
+  ("plan and policies" plus rate-limit pressure, per issue #203 Claim 2). The CCA
+  framing emphasizes backend availability and quality signals rather than the
+  client-side plan/rate-limit inputs the CLI uses. This may reflect genuinely
+  different routing logic, or different marketing language for the same mechanism.
+  Either way, practitioners should not assume CCA auto and CLI auto apply the same
+  routing inputs. For Ch04: when discussing auto-routing as a pattern, distinguish
+  the CLI's rate-limit-mitigation framing from the CCA's system-health framing —
+  they may optimize for different dimensions.
+
+### Claim 3: Auto selection for CCA grants a 10% discount on the normal model multiplier
+
+- **Evidence**: Official changelog states the discount explicitly.
+- **Confidence**: settled (billing mechanic stated definitively in official changelog)
+- **Quote**: "You'll get a 10% discount on the normal model multiplier"
+- **Our assessment**: The 10% multiplier discount matches the CLI auto discount
+  documented in issue #203 (Claim 6). GitHub is applying the same billing incentive
+  structure across both surfaces to steer users toward auto routing. For Ch04:
+  the auto discount is now a cross-surface cost optimization, not just a CLI-specific
+  feature — CCA users benefit from the same 0.9x effective multiplier when they use
+  auto rather than pinning a specific model.
+
+### Claim 4: CCA auto selection users are not impacted by weekly rate limits
+
+- **Evidence**: Official changelog states the rate-limit exemption explicitly alongside
+  the billing discount.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "you won't be impacted by weekly rate limits"
+- **Our assessment**: The rate-limit exemption for CCA auto appears stronger in
+  framing than the CLI version. The CLI note (issue #203, Claim 4) describes auto
+  as "mitigating" rate limits by routing around them — the rate limit still applies
+  as a routing signal. The CCA changelog says users "won't be impacted by weekly
+  rate limits" at all — a more absolute exemption. Whether this is a material
+  difference (CCA auto truly bypasses limits; CLI auto routes around them) or just
+  different changelog wording is not clarified by this source. For teams using
+  CCA for high-volume agent tasks that previously hit weekly rate-limit walls, this
+  is a significant operational change — if the exemption is genuine, auto mode
+  removes a key usage ceiling.
+
+### Claim 5: The auto pool is bounded and respects admin-configured model policies
+
+- **Evidence**: The linked GitHub documentation states: "Auto model selection chooses
+  from the supported models, subject to your policies and subscription type."
+  Additionally the docs indicate models with premium multipliers exceeding 1.0 are
+  excluded from auto selection.
+- **Confidence**: emerging (stated in linked documentation, not directly in the
+  changelog; pool composition not enumerated in the announcement)
+- **Quote**: (no direct quote from changelog; see paraphrase in Our assessment)
+- **Our assessment**: Based on the linked documentation, CCA auto routing respects
+  administrator-configured model restrictions, paralleling the governance behavior
+  documented for CLI auto (issue #203, Claim 7). The pool constraint (models with
+  multipliers ≤ 1.0 only) means Opus-tier models are likely excluded from CCA
+  auto — auto never escalates to higher-cost capability tiers. This is consistent
+  with the CLI auto design. For Ch05: auto is enterprise-safe on the CCA surface
+  as well as the CLI surface — admin restrictions propagate into auto routing,
+  preventing a policy bypass vector.
+
+### Claim 6: CCA auto model selection is distinct from the CLI auto mode and the web-UI manual model selection announced in April 2026
+
+- **Evidence**: Three separate changelog entries with different dates and URLs:
+  CLI auto (April 17, issue #203); web-agent model selection manual (April 14,
+  issue #171); CCA auto (May 14, this source). The linked documentation page
+  lists all Copilot surfaces that support auto: Chat (VS Code, JetBrains GA;
+  Visual Studio, Eclipse, Xcode preview), CLI, and Cloud Agent.
+- **Confidence**: settled (three distinct product announcements)
+- **Quote**: (no direct quote; see paraphrase in Our assessment)
+- **Our assessment**: GitHub has now built model-selection and routing controls
+  across all three primary Copilot surfaces within a 30-day window. The three
+  features are complementary:
+  - Web UI (issue #171): explicit manual selection from a full model pool including
+    Opus tiers, for users who want deliberate capability control
+  - CLI auto (issue #203): automatic routing based on plan + rate-limit pressure,
+    pool capped at 0x–1x multiplier models
+  - CCA auto (this source): automatic routing based on system health + model
+    performance, pool capped at ≤ 1.0x multiplier models
+  For Ch02 and Ch05: advisors and platform engineers should understand that CCA
+  auto mode is not the same as CLI auto mode, even though both are called "auto."
+  The routing inputs, surface context, and available model pools may differ in ways
+  not yet fully documented.
+
+## Concrete Artifacts
+
+### Changelog Entry (verbatim text, May 14, 2026)
+
+```
+Copilot cloud agent now supports Copilot auto model selection.
+
+When you select Auto in the model picker, Copilot intelligently
+selects the best available model based on system health and model
+performance. You'll get a 10% discount on the normal model multiplier,
+and you won't be impacted by weekly rate limits.
+
+To learn more about auto model selection, see our documentation on
+auto model selection.
+```
+*(Source: https://github.blog/changelog/2026-05-14-copilot-cloud-agent-supports-auto-model-selection)*
+
+### GitHub Auto Model Selection — Surface Coverage (as of May 2026, from linked documentation)
+
+```
+Copilot surfaces supporting auto model selection:
+
+Chat:
+  VS Code        — GA
+  JetBrains      — GA
+  Visual Studio  — preview
+  Eclipse        — preview
+  Xcode          — preview
+
+CLI:             — available (documented April 17, 2026, issue #203)
+
+Cloud Agent:     — available (documented May 14, 2026, this source)
+
+Third-party agents (manual, not auto):
+  OpenAI Codex — GPT-5.2-Codex, GPT-5.3-Codex, GPT-5.4, GPT-5.4 nano
+  Anthropic Claude — Opus 4.5/4.6/4.7, Sonnet 4.5/4.6
+
+Auto pool constraint (all surfaces):
+  Models with premium multipliers > 1.0 are excluded from auto routing.
+  Pool composition varies by surface and is subject to change.
+```
+*(Derived from https://docs.github.com/copilot/concepts/auto-model-selection — fetch date 2026-05-15)*
+
+### CCA Auto vs CLI Auto vs Web-Agent Manual — Side-by-Side
+
+```
+Feature                    CLI Auto (#203)           CCA Auto (this)           Web Manual (#171)
+─────────────────────────────────────────────────────────────────────────────────────────────────
+Announcement date          April 17, 2026            May 14, 2026              April 14, 2026
+Selection mode             Automatic                 Automatic                 Manual (user chooses)
+Routing heuristic          Plan + policies +         System health +           N/A (user decides)
+                           rate-limit pressure        model performance
+Model pool cap             0x–1x multiplier only     ≤ 1.0x multiplier only    Full pool (incl. Opus)
+10% multiplier discount    Yes (all paid plans)      Yes                       No
+Rate-limit exemption       Mitigated (routed around) Not impacted (explicit)   N/A
+Admin policy respected     Yes (Claim 7)             Yes (from docs)           Yes (Claim 5)
+Routing transparency       Model shown in CLI output Not stated                N/A (user selected)
+```
+```
+
+## Cross-References
+
+- **Corroborates** `docs-github-copilot-cli-auto-model-selection.md` (issue #203),
+  Claim 6: both CCA auto and CLI auto grant a 10% multiplier discount to paid
+  subscribers who select auto rather than pinning a model. GitHub is applying the
+  same billing incentive across both surfaces.
+
+- **Corroborates** `docs-github-copilot-cli-auto-model-selection.md` (issue #203),
+  Claim 7: both CCA and CLI auto respect admin-configured model policies, making
+  both surfaces enterprise-governance-compatible.
+
+- **Extends** `docs-github-copilot-cli-auto-model-selection.md` (issue #203):
+  the CLI note documented auto routing as a CLI-specific feature; this source
+  extends the auto-routing pattern to the CCA surface. Together they establish
+  auto routing as a cross-surface Copilot primitive, not a CLI-only capability.
+  The "Novel" section of the CLI note ("First source to document CLI-level routing
+  transparency") now has a companion: the CCA source shows GitHub expanding the
+  same incentive structure without necessarily extending the transparency affordance
+  (no model-disclosure mechanism is mentioned for CCA).
+
+- **Extends** `docs-github-copilot-agent-model-selection.md` (issue #171), Claim 1:
+  that source documented the April 2026 addition of explicit model selection for
+  Claude and Codex agents on github.com. This source adds an orthogonal capability:
+  automatic model selection for the CCA surface itself, removing the need for users
+  to make an explicit model choice for routine CCA tasks.
+
+- **Novel**:
+  - First source to document auto model selection specifically for the Copilot
+    Cloud Agent (CCA) surface. Prior sources covered CLI auto (issue #203) and
+    web-agent explicit selection (issue #171); this completes the surface trifecta.
+  - First source to document a CCA routing criterion of "system health and model
+    performance" — a backend-quality framing distinct from the CLI's
+    "plan + policies + rate-limit pressure" framing. Whether these are genuinely
+    different routing systems or the same system described differently is a question
+    future sources may clarify.
+  - First source to assert that CCA auto users "won't be impacted by weekly rate
+    limits" — a stronger claim than the CLI note's "mitigating rate limits."
+
+## Guide Impact
+
+### Chapter 02: Harness Engineering / Daily Tooling
+
+- **CCA model configuration**: Update any description of CCA as a fixed-model or
+  user-configured-model environment. CCA now offers an "Auto" option in the model
+  picker, providing the same auto-routing semantic as the CLI. Teams building CCA
+  harnesses should document whether they pin a model or use auto, and why.
+- **Surface trifecta**: Note that auto/model routing now spans all three primary
+  Copilot surfaces. A team's Copilot tooling strategy now includes a model-routing
+  decision at each surface: explicit on the web UI, auto or explicit on the CLI,
+  auto or explicit on the CCA.
+
+### Chapter 04: Model Selection and Cost Management
+
+- **10% discount across surfaces**: The multiplier discount for auto mode is not
+  CLI-specific — it now also applies to CCA. Teams using CCA for high-volume agent
+  tasks should evaluate switching to auto for the 0.9x effective cost, unless their
+  use case requires a specific model's capabilities.
+- **Rate-limit ceiling removal**: The CCA "won't be impacted by weekly rate limits"
+  claim — if accurate — removes a capacity ceiling that teams currently plan around.
+  Update any guide advice that treats weekly rate limits as a hard constraint for
+  CCA workloads; auto mode may nullify that constraint.
+- **Distinguish auto-routing surfaces**: Ch04 should note that CCA auto and CLI auto
+  use different stated routing heuristics. Teams relying on specific routing behavior
+  (e.g., rate-limit-awareness) should verify which heuristic applies to their surface
+  before depending on it.
+
+### Chapter 05: Enterprise Governance
+
+- **Admin policy propagation to CCA auto**: The linked documentation confirms that
+  CCA auto respects admin model restrictions, paralleling the CLI auto behavior
+  documented in issue #203 Claim 7. Enterprise platform teams can enable CCA auto
+  without creating a policy bypass risk. Update Ch05 governance checklists to note
+  that both CLI and CCA auto modes honor admin restrictions.
+
+## Extraction Notes
+
+1. **Source is very thin**: This is one of the shortest changelogs in the corpus
+   (~100 words). All direct claims are exhausted in six claims above. The routing
+   logic, model pool composition, and governance details require the linked
+   documentation page (https://docs.github.com/copilot/concepts/auto-model-selection)
+   for elaboration.
+2. **Documentation page consulted**: The linked documentation page was fetched
+   (2026-05-15) and used for Claims 5 and 6 and the Concrete Artifacts section.
+   Quotes from the docs page are marked as paraphrased where verbatim accuracy
+   could not be confirmed; the changelog verbatim text is confirmed in Claims 1-4.
+3. **Rate-limit claim ambiguity**: The CCA changelog says "won't be impacted by
+   weekly rate limits" — a stronger phrasing than the CLI's "mitigating rate limits."
+   Whether this is a material difference or marketing language variation is unclear.
+   Do not rely on this claim for hard capacity planning without independent
+   verification.
+4. **Model pool not enumerated in announcement**: Unlike the CLI auto changelog
+   (issue #203), this CCA changelog does not list specific models in the auto pool.
+   The pool composition is derived from the linked documentation and may differ
+   from the CLI pool (GPT-5.4, GPT-5.3-Codex, Sonnet 4.6, Haiku 4.5 as of
+   April 2026). Do not assume the pools are identical.
+5. **No contradictions filed**: The difference in routing heuristic framing
+   (CCA: "system health and model performance" vs. CLI: "plan + policies + rate-limit
+   pressure") is a difference in framing, not a direct material contradiction leading
+   to different guide advice. Both encourage auto use; both honor admin policies;
+   both offer the 10% discount. No contradiction issue required.


### PR DESCRIPTION
Source note extracted by the Miner agent for #745.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.
