### PR TITLE
source: docs-github-copilot-cca-apply-review-feedback (#833)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -1411,5 +1411,18 @@
     "file": "source-notes/docs-github-copilot-web-contextual-chat.md",
     "confidence_overall": "settled",
     "status": "current"
+  },
+  "docs-github-copilot-cca-apply-review-feedback": {
+    "slug": "docs-github-copilot-cca-apply-review-feedback",
+    "title": "Easily apply Copilot code review feedback with Copilot cloud agent",
+    "source_url": "https://github.blog/changelog/2026-05-19-easily-apply-copilot-code-review-feedback-with-copilot-cloud-agent",
+    "source_type": "docs",
+    "author": "GitHub (official changelog)",
+    "date_published": "2026-05-19",
+    "date_extracted": "2026-05-21",
+    "issue": "#833",
+    "file": "source-notes/docs-github-copilot-cca-apply-review-feedback.md",
+    "confidence_overall": "settled",
+    "status": "current"
   }
 }

--- a/source-notes/docs-github-copilot-cca-apply-review-feedback.md
+++ b/source-notes/docs-github-copilot-cca-apply-review-feedback.md
@@ -1,0 +1,442 @@
+---
+source_url: https://github.blog/changelog/2026-05-19-easily-apply-copilot-code-review-feedback-with-copilot-cloud-agent
+source_type: docs
+title: "Easily apply Copilot code review feedback with Copilot cloud agent"
+author: GitHub (official changelog)
+date_published: 2026-05-19
+date_extracted: 2026-05-21
+last_checked: 2026-05-21
+status: current
+confidence_overall: settled
+issue: "#833"
+---
+
+# Easily Apply Copilot Code Review Feedback with Copilot Cloud Agent
+
+> GitHub's May 19, 2026 changelog announcing two interaction improvements to Copilot
+> code review's suggestion-application workflow: the "Implement suggestion" button is
+> replaced by a "Fix with Copilot" dialog giving users control over application target,
+> model, and custom instructions; and a new "Fix batch with Copilot" button enables
+> selective batch application of multiple comments at once.
+
+## Source Context
+
+- **Type**: docs (GitHub official product changelog, ~200 words, May 19, 2026; two
+  named sections: "A clearer handoff from review to code change" and "Ask Copilot
+  to address multiple comments at once")
+- **Author credibility**: GitHub engineering team announcing a production feature
+  change. Authoritative for: the button rename, the dialog options (application target,
+  model selection, additional instructions), the batch feature mechanics, and the
+  contrast with prior behavior. Not a credible source for: which specific comment types
+  or suggestion categories are eligible for CCA application, success rates, billing
+  implications of invoking CCA via this dialog, or whether the feature requires the
+  new pull requests experience (this source is silent on that prerequisite).
+- **Scope**: Two specific interaction changes to Copilot code review's suggestion-
+  application surface, both scoped to the existing Copilot code review feature.
+  Does NOT cover: how CCA processes the suggestion once the dialog is confirmed,
+  what happens if CCA cannot apply a suggestion cleanly, conflict handling when the
+  branch has diverged, billing for the CCA invocation triggered by the dialog, or
+  whether organizational admin controls (CCA enablement) gate the new buttons.
+
+## Extracted Claims
+
+### Claim 1: The "Implement suggestion" button in Copilot code review has been renamed to "Fix with Copilot" and now shows a pre-handoff dialog for user control before invoking CCA
+
+- **Evidence**: Official GitHub product changelog explicitly states the rename and
+  describes the dialog as a new control surface. Present-tense framing indicates this
+  is a shipped change, not a preview.
+- **Confidence**: settled (product fact — stated in official changelog)
+- **Quote**: "Copilot code review's previous Implement suggestion button has now been
+  renamed to Fix with Copilot and updated to support a UI dialog for more control over
+  how suggestions are applied."
+- **Our assessment**: The rename from "Implement suggestion" to "Fix with Copilot" is
+  more than cosmetic — it shifts the semantic frame from passive implementation (the
+  tool implements your suggestion) to active agent delegation (you're asking Copilot
+  to fix something). The addition of a dialog before the handoff is a structural change
+  to the interaction model: the user now has an explicit decision point between clicking
+  the button and CCA beginning work. This addresses a common objection to AI-assisted
+  code review: the lack of control over what the AI does once you accept a suggestion.
+  For Ch01 (Daily Workflows): practitioners using Copilot code review should update
+  their mental model — the interaction is now: click button → configure dialog →
+  confirm handoff → CCA applies, rather than click button → CCA acts immediately.
+
+### Claim 2: The "Fix with Copilot" dialog offers three user controls: application target (direct PR or new PR), model selection, and optional additional instructions
+
+- **Evidence**: Three explicit bullet points in the official changelog enumerating
+  the dialog's options.
+- **Confidence**: settled (stated as an explicit list in official changelog)
+- **Quote** (first option): "Choose whether to apply the change directly to your pull
+  request or open a new pull request targeting your branch."
+- **Quote** (second option): "Select the model you want Copilot to use when implementing
+  the changes."
+- **Quote** (third option): "Add optional additional instructions to guide the changes."
+- **Our assessment**: The three dialog controls represent meaningfully different
+  practitioner choices.
+  - *Application target*: Applying directly to the current PR is faster but mixes
+    Copilot's changes into the PR's commit history. Opening a new PR targeting the
+    branch is safer for review: it creates a visible, separate commit set that can be
+    merged or rejected cleanly. For high-trust suggestions (trivial style fixes) teams
+    may prefer direct application; for structural suggestions (logic changes), a new PR
+    keeps CCA's contribution auditable.
+  - *Model selection*: Exposing model choice in the dialog surface means the user can
+    apply the same cost/capability tradeoffs available in other CCA contexts (see
+    `docs-github-copilot-cca-cost-efficient-models.md` Claim 2: Haiku 4.5 at 0.33x,
+    GPT-5.4-mini at 0.33x). A trivial formatting fix likely warrants a budget-tier
+    model; a complex refactoring suggestion warrants a more capable model.
+  - *Additional instructions*: The ability to add instructions at the dialog stage
+    closes the feedback loop between the review comment and the CCA execution — the
+    user can say "apply this suggestion but preserve backward compatibility" without
+    requiring a separate conversation.
+
+### Claim 3: The previous "Implement suggestion" behavior triggered CCA silently by generating a comment that tagged @Copilot on the user's behalf to open a new PR
+
+- **Evidence**: The changelog contrasts the old and new behavior explicitly in the
+  "A clearer handoff from review to code change" section.
+- **Confidence**: settled (explicitly stated as prior behavior in official changelog)
+- **Quote**: "Previously, clicking Implement suggestion would generate a comment
+  tagging @Copilot on your behalf to open a new pull request with the necessary
+  changes."
+- **Our assessment**: The prior mechanism (generate a @Copilot comment to trigger
+  CCA) was opaque and non-configurable — users had no insight into or control over
+  the invocation parameters before CCA started working. The changelog makes clear that
+  the dialog is a direct replacement for this implicit comment mechanism. For Ch02
+  (Harness Engineering): the old @Copilot comment trigger is no longer the mechanism;
+  it has been replaced by the dialog-driven invocation. Any guide content describing
+  the "tagging @Copilot" pattern as the way to apply code review suggestions should
+  be updated.
+
+### Claim 4: The "Implement all suggestions" button in the Pull Request Overview comment has been replaced with "Fix batch with Copilot," enabling selective batch application
+
+- **Evidence**: Official changelog explicitly states the button replacement and
+  describes the new batch behavior.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "Additionally, the Implement all suggestions button located on Copilot's
+  Pull Request Overview comment has been replaced with the Fix batch with Copilot
+  button. This allows you to batch together specific feedback before handing it off
+  to Copilot cloud agent."
+- **Our assessment**: The semantic shift from "Implement all suggestions" to "Fix batch
+  with Copilot" is substantive: the old button was all-or-nothing (apply every
+  suggestion); the new button is selective (apply chosen suggestions). The word
+  "batch" here is user-controlled, not automated — the user selects which comments
+  to include before triggering CCA. For Ch01: this resolves a practical problem with
+  the prior all-suggestions approach — practitioners were reluctant to apply all
+  Copilot suggestions at once because they might not agree with all of them. Selective
+  batching means they can apply, say, the five formatting suggestions without also
+  applying the three structural suggestions they want to review more carefully.
+
+### Claim 5: The "Fix batch with Copilot" feature lets users select which specific comments to include in the batch, rather than applying all suggestions indiscriminately
+
+- **Evidence**: The changelog explicitly states that users "select which comments
+  should be applied" in the batch invocation.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "you can ask Copilot cloud agent to address multiple Copilot code review
+  comments at once and select which comments should be applied."
+- **Our assessment**: User-controlled comment selection is the key differentiator
+  from the old "Implement all suggestions" button. Combined with the severity labels
+  introduced May 12 (see `docs-github-copilot-code-review-comment-ux.md` Claims 1
+  and 3), a practitioner's workflow is now: (1) scan comments by severity, (2) select
+  High-severity ones for manual attention, (3) batch "Fix with Copilot" the
+  Low-severity or Medium-severity mechanical fixes. The two feature updates (May 12
+  severity labels + May 19 batch selection) form a coherent review-triage-and-act
+  workflow.
+
+### Claim 6: The changelog frames the change as providing "a clearer handoff from review to code change" — the pre-handoff dialog is explicitly positioned as a control improvement for the review-to-implementation transition
+
+- **Evidence**: The phrase is used as the heading for the first section of the
+  changelog entry, framing the intent of the dialog change.
+- **Confidence**: settled (stated as a section heading in the changelog, i.e., the
+  vendor's stated intent)
+- **Quote**: "A clearer handoff from review to code change"
+- **Our assessment**: The "handoff" framing is architecturally significant. It
+  positions the "Fix with Copilot" button as a boundary between the review phase
+  (human reading and triaging Copilot comments) and the implementation phase (CCA
+  applying the accepted suggestions). By making the handoff explicit (a dialog) rather
+  than implicit (a comment trigger), GitHub is acknowledging that practitioners need
+  a moment of control and visibility at this boundary. For Ch03 (Safety and
+  Verification): the dialog is a structured human-in-the-loop gate at the
+  review-to-implementation boundary — not just a UX improvement, but an architectural
+  safety mechanism that prevents CCA from acting before the user has confirmed the
+  parameters of its work.
+
+### Claim 7: The batch efficiency improvement — multiple comments handled in one CCA invocation rather than one by one — is the stated rationale for the "Fix batch with Copilot" feature
+
+- **Evidence**: The second section of the changelog provides this framing explicitly.
+- **Confidence**: settled (stated framing in official changelog)
+- **Quote**: "This helps you act on multiple comments more efficiently instead of
+  handling each one individually."
+- **Our assessment**: The efficiency framing is consistent with GitHub's broader pattern
+  of reducing friction in AI code review adoption (see `docs-github-copilot-code-review-comment-ux.md`
+  Claim 3: the May 12 changelog explicitly framed grouping and severity as "reduce
+  noise" features). The May 19 changelog continues the same theme: once you've triaged
+  (May 12's noise-reduction features), acting on the result is now more efficient (May 19's
+  batch application). Together these two changelog entries complete a triage-then-act workflow
+  arc for Copilot code review. For Ch05 (Team Adoption): when evaluating Copilot code review
+  for high-volume review teams, both the triage improvements (severity, grouping) and
+  the acting improvements (dialog, batch) should be presented together as the complete May 2026
+  friction-reduction suite.
+
+## Concrete Artifacts
+
+### Full Verbatim Text of Source Changelog (May 19, 2026)
+
+```
+Title: Easily apply Copilot code review feedback with Copilot cloud agent
+Published: May 19, 2026
+Category: Improvement
+Source: https://github.blog/changelog/2026-05-19-easily-apply-copilot-code-review-feedback-with-copilot-cloud-agent
+
+--- SECTION: A clearer handoff from review to code change ---
+
+Copilot code review's previous Implement suggestion button has now been renamed to
+Fix with Copilot and updated to support a UI dialog for more control over how
+suggestions are applied. Now you can define what happens next and control how the
+fix should be applied. Additionally, the Implement all suggestions button located on
+Copilot's Pull Request Overview comment has been replaced with the Fix batch with
+Copilot button. This allows you to batch together specific feedback before handing
+it off to Copilot cloud agent.
+
+Previously, clicking Implement suggestion would generate a comment tagging @Copilot
+on your behalf to open a new pull request with the necessary changes. Now, when you
+click the Fix with Copilot button on a Copilot code review comment, you'll see a
+dialog before the handoff begins. From there, you can:
+
+  - Choose whether to apply the change directly to your pull request or open a new
+    pull request targeting your branch.
+  - Select the model you want Copilot to use when implementing the changes.
+  - Add optional additional instructions to guide the changes.
+
+--- SECTION: Ask Copilot to address multiple comments at once ---
+
+With the new Fix batch with Copilot button in Copilot's Pull Request Overview
+comment, you can ask Copilot cloud agent to address multiple Copilot code review
+comments at once and select which comments should be applied.
+
+This helps you act on multiple comments more efficiently instead of handling each
+one individually.
+```
+
+### Feature Summary: "Fix with Copilot" Dialog and Batch for Code Review
+
+```
+Feature 1: "Fix with Copilot" Button (replaces "Implement suggestion")
+  Entry point:     Copilot code review comment
+  Behavior:        Shows a pre-handoff dialog before CCA begins work
+  Dialog controls:
+    1. Application target — direct PR commit OR new PR targeting the branch
+    2. Model selection    — user selects which Copilot model implements the change
+    3. Additional instructions — optional free-text to guide the implementation
+
+  Prior behavior (replaced):
+    Clicking "Implement suggestion" → auto-generated @Copilot comment → CCA opens new PR
+    (no user dialog; no control over application target, model, or instructions)
+
+Feature 2: "Fix batch with Copilot" Button (replaces "Implement all suggestions")
+  Entry point:     Copilot's Pull Request Overview comment
+  Behavior:        User selects which code review comments to include, then CCA
+                   addresses all selected comments in a single invocation
+  Advantage over prior button:
+    Old "Implement all suggestions" → applied ALL suggestions at once (no selectivity)
+    New "Fix batch with Copilot"    → user selects which comments to batch (selective)
+
+Published: 2026-05-19
+Source: GitHub official product changelog
+```
+
+### Copilot Code Review — May 2026 Feature Evolution Arc
+
+```
+Date         Source Note                                      What Changed
+-----------  -----------------------------------------------  ----------------------------------------
+2026-04-27   docs-github-copilot-code-review-actions-billing  Billing: PRU → dual billing (AI Credits
+                                                              + Actions minutes) effective June 1, 2026.
+                                                              Agentic architecture on GitHub Actions.
+
+2026-05-12   docs-github-copilot-code-review-comment-ux       Triage: severity labels (High/Med/Low),
+                                                              comment grouping, "updated changeset UI"
+                                                              (vaguely referenced).
+
+2026-05-19   THIS NOTE (docs-github-copilot-cca-apply-        Act: "Fix with Copilot" dialog (replaces
+             review-feedback)                                 "Implement suggestion"); "Fix batch with
+                                                              Copilot" (replaces "Implement all").
+                                                              The "updated changeset UI" from May 12
+                                                              is now specified concretely.
+
+Together: April 27 = billing/infrastructure; May 12 = triage surface; May 19 = action surface.
+The three sources form the complete May 2026 code review improvement arc.
+```
+
+## Cross-References
+
+- **Extends** `docs-github-copilot-code-review-comment-ux.md` (issue #723), specifically Claim 4:
+  That source documented the May 12 changelog which mentioned "an updated suggested changeset
+  UI will reduce noise" without elaborating on what changed. This source reveals exactly what
+  that UI update was: the rename of "Implement suggestion" to "Fix with Copilot" plus the new
+  dialog. The May 12 note's Claim 4 assessment correctly noted "The changelog mentions this
+  third change without elaborating on what changed in the UI beyond 'reduce noise.'" That gap
+  is now closed. Together the two changelog entries are inseparable in explaining the full
+  May 2026 code review surface: May 12 introduced the triage layer (severity, grouping);
+  May 19 introduced the action layer (dialog, batch). The May 12 note also introduced
+  severity labels (Claim 1) and comment grouping (Claim 2) — practitioners can now use these
+  to inform which comments they select for batch application via the May 19 feature.
+
+- **Extends** `docs-github-copilot-code-review-actions-billing.md` (issue #445), specifically
+  Claim 2: That source established that Copilot code review "runs on agentic tool-calling
+  architecture" on GitHub Actions. The May 19 "Fix with Copilot" dialog is a user-visible
+  invocation point for that same agentic architecture — users are now explicitly choosing to
+  invoke CCA, with control over which model it uses and how it applies the fix. The dialog's
+  model selection option (Claim 2 of this note) directly connects to the cost implications
+  of that billing source: each "Fix with Copilot" invocation via dialog or batch will consume
+  AI Credits and (for private repos) GitHub Actions minutes per the June 1, 2026 billing
+  change. Practitioners who heavily use batch application should account for the Actions
+  minute consumption per invocation when estimating post-June 1 code review costs.
+
+- **Corroborates** `docs-github-copilot-cca-fix-failing-actions.md` (issue #819), Claim 1:
+  That source (May 18, 2026) documented a different "Fix with Copilot" button on the workflow
+  run logs page for fixing failing GitHub Actions jobs. This source (May 19, 2026) introduces
+  a same-named "Fix with Copilot" button in the code review comment surface. The two share
+  a brand name but are distinct entry points: the Actions-failure button (May 18) targets
+  CI failures on PR branches with no pre-invocation dialog; the code review button (May 19)
+  targets code review suggestions with a three-option pre-handoff dialog. Together they
+  establish that "Fix with Copilot" is GitHub's unified CCA invocation brand across product
+  surfaces — CI failure remediation and code review feedback application both use this
+  button name. The execution model also differs: the May 18 button has CCA push directly to
+  the branch; the May 19 button lets the user choose direct application or a new PR. For
+  Ch02: these are two distinct CCA entry points that should be documented separately despite
+  sharing a button label.
+
+- **Complements** `docs-github-copilot-cca-cost-efficient-models.md` (issue #818), Claim 2:
+  That source (May 18, 2026) announced that Haiku 4.5 (0.33x) and GPT-5.4-mini (0.33x) were
+  added to CCA's model roster, and Claim 3 provided GitHub's task-complexity-based selection
+  guidance ("a smaller, quicker model for straightforward changes, or a more capable model
+  for complex work"). The May 19 code review dialog's model selection option exposes these
+  same models to practitioners applying code review suggestions. The cost-efficiency guidance
+  from May 18 is directly applicable here: use budget-tier models for routine style/formatting
+  review suggestions; use capable-tier models for structural or logic suggestions. This is a
+  case where two announcements published one day apart form a coherent practitioner guidance
+  pair: May 18 expanded the model menu; May 19 added a code review entry point that exposes
+  that menu. For Ch02 and Ch04: cross-reference both when documenting CCA model selection
+  for code review application.
+
+- **Contradicts**: None found. No existing source note claims that applying Copilot code
+  review suggestions is automatic or that the prior "Implement suggestion" behavior was
+  better than the new dialog model. No contradiction issue to file.
+
+- **Novel**:
+  - First corpus source to document a pre-handoff dialog as a human-in-the-loop gate at
+    the review-to-CCA-invocation boundary for code review. Prior CCA invocation paths
+    (issue assign, @copilot in PR, REST API, workflow failure button) all proceed without
+    a configuration dialog; this is the first CCA entry point with a three-option
+    pre-invocation control surface.
+  - First corpus source to document user-selectable model choice at the moment of
+    code review suggestion application — surfacing the model roster in the code review
+    UX surface specifically.
+  - First corpus source to document user-selective batch application of code review
+    comments (as opposed to all-or-nothing "Implement all suggestions"). Selective
+    batching as a UX pattern for AI code review is novel in the corpus.
+  - First corpus source to document the prior @Copilot comment-tagging mechanism as
+    the implementation of "Implement suggestion" — this retrospective detail was not
+    captured in any prior source note.
+
+## Guide Impact
+
+### Chapter 01: Daily Workflows
+
+- **Update Copilot code review application workflow**: Add the new two-step triage-
+  and-act workflow enabled by the May 2026 improvements. Step 1 (triage): use severity
+  labels (High/Med/Low, per `docs-github-copilot-code-review-comment-ux.md`) to
+  prioritize which comments need attention. Step 2 (act): for comments worth applying,
+  use "Fix with Copilot" for individual suggestions (with dialog control over
+  application target, model, and instructions) or "Fix batch with Copilot" for
+  applying multiple selected suggestions in one invocation. The key practitioner
+  choice: direct PR application (faster, no separate PR to merge) vs. new PR
+  (more auditable, clean diff for review). Recommend new PR for any structural
+  suggestions; direct application for unambiguous mechanical fixes (formatting, naming).
+
+- **Remove "Implement suggestion" / "Implement all suggestions" guidance**: Any
+  guide content referencing these button names is now outdated. The "Implement
+  suggestion" button no longer exists. Teams reading the guide should use "Fix with
+  Copilot" and "Fix batch with Copilot" as the current interaction vocabulary.
+
+### Chapter 02: Harness Engineering
+
+- **Add "Fix with Copilot" dialog as a CCA invocation path**: The code review dialog
+  is a distinct CCA invocation mechanism from the "Fix with Copilot" button on workflow
+  run logs (`docs-github-copilot-cca-fix-failing-actions.md`). Both share the button
+  name but differ in entry point, dialog behavior, and application scope. Document them
+  separately to avoid conflating CI-failure remediation with code-review suggestion
+  application. Key difference: the code review dialog offers application target choice;
+  the Actions-failure button does not.
+
+- **Model selection at dialog = cost lever**: The model selection in the "Fix with
+  Copilot" dialog is a concrete cost optimization point for teams making heavy use of
+  code review suggestion application. Teams that default to Opus for all CCA invocations
+  can reduce cost substantially by selecting Haiku 4.5 (0.33x multiplier) for
+  straightforward formatting or style suggestions. Cross-reference `docs-github-copilot-cca-cost-efficient-models.md`
+  for the three-tier decision matrix.
+
+### Chapter 03: Safety and Verification
+
+- **Dialog as structured human-in-the-loop gate**: The pre-handoff dialog is the first
+  CCA entry point documented in the corpus that requires explicit user configuration
+  before CCA begins. Frame this in Ch03 as a structural safety mechanism: CCA cannot
+  apply a code review suggestion until the user has explicitly chosen the application
+  target, model, and (optionally) additional instructions. This is a stronger human-
+  in-the-loop guarantee than the silent @Copilot comment trigger it replaced. The
+  dialog creates an intentional confirmation step that prevents accidental CCA
+  invocations from casual button-clicking.
+
+### Chapter 05: Team Adoption
+
+- **Copilot code review re-evaluation with the full May 2026 feature set**: Teams that
+  evaluated Copilot code review before May 2026 should reassess with the complete
+  feature suite: severity labels + comment grouping (May 12) + controlled application
+  dialog + selective batch (May 19). The prior pain points — "all suggestions have
+  equal weight," "same comment repeated N times," "no control over how suggestions
+  are applied," "all-or-nothing suggestion acceptance" — are each directly addressed by
+  specific shipped features in the corpus. Present these four improvements as a
+  friction-reduction package, not as individual incremental updates.
+
+- **Selective batch as a team workflow accelerator**: For teams with high PR volume,
+  "Fix batch with Copilot" with comment selection enables a practical triage → batch
+  workflow that was not possible before. A PR author can apply all selected mechanical
+  fixes in one CCA invocation while retaining human judgment for substantive suggestions.
+  This can meaningfully reduce the per-PR review closure time for PRs with many
+  Copilot code review comments, particularly for teams where review completion speed is
+  a bottleneck.
+
+## Extraction Notes
+
+1. **Source is ~200 words**: This is a short product changelog. Seven claims above
+   exhaust the factual content of both sections. The source was read in full including
+   both named sections. The table of contents items duplicate the section headings;
+   no new information was present there.
+
+2. **Billing implications not documented**: The source does not address whether invoking
+   CCA via the "Fix with Copilot" dialog or "Fix batch with Copilot" consumes GitHub
+   Actions minutes in addition to AI Credits. Given that `docs-github-copilot-code-review-actions-billing.md`
+   Claim 2 establishes that Copilot code review runs on GitHub Actions infrastructure,
+   Actions minute consumption is likely but not confirmed by this source. Practitioners
+   should treat the June 1, 2026 billing change (dual: AI Credits + Actions minutes for
+   private repos) as applying to these new invocations until GitHub confirms otherwise.
+
+3. **Admin enablement prerequisite not stated**: Unlike `docs-github-copilot-cca-fix-failing-actions.md`
+   (Claim 5), this source does not state whether the "Fix with Copilot" dialog and
+   batch feature require Copilot cloud agent to be enabled by an org admin. Given that
+   both are CCA invocations, the admin-enablement requirement documented for the
+   Actions-failure button likely applies here too, but this is not confirmed from the
+   source text. Noted as a gap.
+
+4. **"Apply directly to your pull request" mechanics not specified**: The dialog offers
+   applying "directly to your pull request" but the changelog does not specify whether
+   this means a direct commit to the PR branch, a suggested change comment, or another
+   mechanism. Practitioners choosing this option should test the behavior before relying
+   on it in production workflows.
+
+5. **No sub-pages followed**: The changelog contains a "Join the discussion within
+   GitHub Community" footer link. No substantive linked content was present.
+
+6. **No contradictions filed**: All claims are consistent with the existing corpus. The
+   feature is a replacement for the prior button behavior, not a contradiction of any
+   existing source note's claims about code review. The May 12 note's Claim 4 gap
+   (unspecified "updated changeset UI") is now filled by this source but is not a
+   contradiction — it is the same update described in more detail.


### PR DESCRIPTION
Source note extracted by the Miner agent for #833.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.
