### PR TITLE
source: docs-github-copilot-vscode-auto-model-selection (#844)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -1437,5 +1437,18 @@
     "file": "source-notes/docs-github-copilot-cca-apply-review-feedback.md",
     "confidence_overall": "settled",
     "status": "current"
+  },
+  "docs-github-copilot-vscode-auto-model-selection": {
+    "slug": "docs-github-copilot-vscode-auto-model-selection",
+    "title": "Auto model selection now routes based on your task in VS Code",
+    "source_url": "https://github.blog/changelog/2026-05-20-auto-model-selection-now-routes-based-on-your-task-in-vs-code",
+    "source_type": "docs",
+    "author": "GitHub (official changelog)",
+    "date_published": "2026-05-20",
+    "date_extracted": "2026-05-22",
+    "issue": "#844",
+    "file": "source-notes/docs-github-copilot-vscode-auto-model-selection.md",
+    "confidence_overall": "settled",
+    "status": "current"
   }
 }

--- a/source-notes/docs-github-copilot-vscode-auto-model-selection.md
+++ b/source-notes/docs-github-copilot-vscode-auto-model-selection.md
@@ -1,0 +1,424 @@
+---
+source_url: https://github.blog/changelog/2026-05-20-auto-model-selection-now-routes-based-on-your-task-in-vs-code
+source_type: docs
+title: "Auto model selection now routes based on your task in VS Code"
+author: GitHub (official changelog)
+date_published: 2026-05-20
+date_extracted: 2026-05-22
+last_checked: 2026-05-22
+status: current
+confidence_overall: settled
+issue: "#844"
+---
+
+# Auto Model Selection Now Routes Based on Your Task in VS Code
+
+> GitHub's May 20, 2026 VS Code auto model selection announcement introduces task-complexity-aware
+> routing as a first-class routing input — the first GitHub Copilot auto-routing surface that
+> evaluates *what you are asking for*, not just plan constraints and rate-limit pressure, making
+> it a genuinely distinct implementation from the CLI auto mode documented in issue #203.
+
+## Source Context
+
+- **Type**: docs (GitHub official product changelog, May 20, 2026; approximately 200 words of
+  primary announcement text, tagged "Improvement", estimated 1-minute read)
+- **Author credibility**: GitHub engineering team announcing a production feature change in
+  GitHub Copilot for VS Code. Authoritative for the existence of the feature, the specific
+  routing dimensions evaluated, the billing mechanics, and the admin governance behavior.
+  Not a credible source for: which specific models are in the auto pool, how the routing
+  algorithm weights the four task dimensions against each other, what "natural cache
+  boundaries" means technically, or whether task-aware routing produces measurably better
+  task outcomes than cost-driven routing.
+- **Scope**: The auto model selection feature specifically in GitHub Copilot for VS Code —
+  not CLI, not github.com cloud agents, not Visual Studio. Covers routing logic (task
+  dimensions + real-time availability), billing mechanics (0x–1x pool, 10% discount),
+  admin policy enforcement, transparency affordance (hover-to-see-model), and cache
+  boundary optimization. Does NOT cover: which specific models are in the auto pool,
+  how the routing weights task dimensions against availability signals, whether model
+  selection can be pinned per workspace or only per session, how VS Code auto interacts
+  with multi-file agent sessions vs. single-file completions, or cost data comparing
+  task outcomes across models.
+
+## Extracted Claims
+
+### Claim 1: VS Code auto model selection is task-complexity-aware, evaluating task dimensions to route to the optimal model
+
+- **Evidence**: Official GitHub product changelog. The routing logic is described with four
+  explicit evaluation dimensions. This is the primary new claim in the announcement — the
+  feature title ("routes based on your task") is substantiated by the routing description.
+- **Confidence**: settled (task dimensions stated in official changelog; existence of the
+  feature is a product fact)
+- **Quote**: "Auto weighs real-time model availability and reliability signals, then evaluates
+  your task across several dimensions like reasoning, code generation complexity, bug diagnosis
+  difficulty, and tool orchestration needs to select the optimal model."
+- **Our assessment**: This is the defining difference between VS Code auto and CLI auto.
+  The CLI auto mode (issue #203, Claim 2) routes based on plan + policies + rate-limit
+  pressure — explicitly NOT on task type. VS Code auto adds a second routing layer: task
+  content analysis across four dimensions. For practitioners, this means VS Code auto is
+  not merely a cost/availability optimizer — it is attempting to select the model best suited
+  for the work at hand. A bug diagnosis task routes differently than a code generation task.
+  The specific four dimensions (reasoning, code generation complexity, bug diagnosis difficulty,
+  tool orchestration needs) map directly to the task types that practitioners face when using
+  Copilot interactively in the IDE. For Ch02: VS Code auto should be recommended as the
+  default IDE routing choice precisely because it accounts for task type in addition to
+  availability constraints. The CLI auto note's earlier assessment — "for practitioners who
+  want task-aware routing, explicit model selection remains the only option" — is no longer
+  accurate for the VS Code surface.
+
+### Claim 2: Auto routing combines two input categories simultaneously: task analysis and real-time model availability and reliability signals
+
+- **Evidence**: Official changelog opening sentence describes the dual-input routing architecture.
+  The word "then" in the routing description (Claim 1 quote) implies availability is checked
+  first, then task dimensions are applied — though the ordering may be our interpretation.
+- **Confidence**: settled (dual-input routing stated in official changelog)
+- **Quote**: "GitHub Copilot auto model selection now routes to the best model for your task,
+  using utilization and model health metrics for a high quality, reliable, and token-efficient
+  experience."
+- **Our assessment**: The combination of task analysis + real-time availability signals makes
+  VS Code auto a more sophisticated router than the CLI auto (which only routes on availability/
+  rate-limits). The "utilization and model health metrics" framing suggests GitHub is monitoring
+  per-model health in real time — not just whether a model is rate-limited, but whether it is
+  performing reliably (latency, error rates, etc.). For practitioners: VS Code auto provides
+  a form of graceful degradation where routing will shift if a preferred model for a task type
+  is degraded, not just rate-limited. For Ch02: document this as a resilience property of auto
+  mode — it is more than a cost tool; it provides reliability isolation from individual model
+  incidents.
+
+### Claim 3: The VS Code auto pool is bounded to 0x–1x premium request multiplier models
+
+- **Evidence**: Official changelog states the billing constraint explicitly alongside the
+  discount information.
+- **Confidence**: settled (billing constraint stated in official changelog)
+- **Quote**: "Auto is billed based on the model it selects, which is currently limited to
+  models with 0x to 1x multipliers."
+- **Our assessment**: The same 0x–1x pool constraint applies to both VS Code auto and CLI
+  auto (issue #203, Claim 3). Despite VS Code auto's task-aware routing, it will not
+  escalate to Opus-tier models (which carry multipliers above 1x) regardless of task
+  complexity. A highly complex reasoning task will be routed to the most capable model
+  *within the 0x–1x band* — not to the most capable model available. This is the key
+  constraint practitioners must understand: VS Code auto is task-aware within a cost-bounded
+  pool. For tasks that genuinely require Opus-tier capability (deep cross-codebase reasoning,
+  large context analysis), explicit model selection remains necessary. The guide should
+  frame auto's task-awareness as "selects the right model for the job within the budget
+  pool," not "always selects the best possible model for the task."
+
+### Claim 4: Paid subscribers get a 10% discount on the model multiplier when using VS Code auto
+
+- **Evidence**: Official changelog states the billing discount. This matches the identical
+  mechanic in the CLI auto announcement (issue #203, Claim 6), suggesting a consistent
+  platform-wide billing incentive for auto adoption.
+- **Confidence**: settled (billing mechanic stated in official changelog)
+- **Quote**: "Paid subscribers get a 10% discount on the model multiplier when using auto"
+- **Our assessment**: The 10% discount is the same as the CLI auto discount, confirming
+  that GitHub applies a consistent billing incentive to auto mode across both the CLI and
+  VS Code surfaces. The incentive structure signals GitHub's operational preference: auto
+  routing is more efficient for the platform (predictable load distribution, cache reuse),
+  and GitHub passes some of that efficiency back to the user. For Ch04: document the 10%
+  auto discount as a cross-surface billing pattern — teams that use auto mode in both the
+  CLI and VS Code compound this saving across all auto-routed requests. The effective cost
+  of the same 1x model is 0.9x when auto-selected vs. 1.0x when explicitly pinned.
+
+### Claim 5: VS Code auto routes along natural cache boundaries to minimize token costs
+
+- **Evidence**: Official changelog states the cache-aware routing behavior as a cost
+  optimization feature.
+- **Confidence**: settled (stated in official changelog; no implementation details provided)
+- **Quote**: "Auto routes along natural cache boundaries to avoid unnecessary cache related
+  costs"
+- **Our assessment**: This is the most novel cost-optimization claim in the source — no
+  prior corpus note documents cache-boundary-aware routing in any GitHub Copilot surface.
+  "Natural cache boundaries" likely refers to prompt caching: routing to the same model
+  consistently for a given context allows the provider's prompt cache to remain warm,
+  reducing per-token costs for repeated or related requests. If auto routes arbitrarily
+  across models, the prompt cache would be cold for each switch, increasing effective
+  token costs even if the multiplier discount applies. The cache-boundary routing implies
+  VS Code auto has some form of session-level or context-level routing consistency, not
+  purely per-request random selection. For Ch04: this is a meaningful cost argument for
+  auto beyond the 10% multiplier discount — cache efficiency may produce additional token
+  savings, particularly in long interactive sessions. Teams should not assume cache savings
+  are additive to the multiplier discount without confirmation from GitHub.
+
+### Claim 6: Users can see which model was used by hovering over the model response in VS Code
+
+- **Evidence**: Official changelog describes the transparency affordance explicitly.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "You can see which model was used by hovering over the model response"
+- **Our assessment**: This is the VS Code-specific transparency mechanism. The CLI auto
+  mode surfaces model selection differently — "you can see which model was used directly
+  in the Copilot CLI" (issue #203, Claim 5), which implies output-level disclosure (likely
+  printed in the terminal after each request). VS Code uses hover-based disclosure in the
+  chat/completions UI. Both approaches give practitioners access to the routing decision,
+  but the VS Code affordance is more passive (it does not interrupt the interaction flow).
+  For harness engineering: teams that want to log which model was selected in VS Code
+  sessions cannot directly capture hover metadata programmatically — unlike the CLI,
+  where the model name is surfaced in terminal output that can be piped or logged. For
+  Ch02: note that observability of auto-routing decisions differs by surface and affects
+  the feasibility of building empirical routing datasets.
+
+### Claim 7: Users can switch between Auto and any specific model at any time in VS Code
+
+- **Evidence**: Official changelog states this control explicitly.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "Switch between Auto and any specific model at any time"
+- **Our assessment**: Same user-control principle as CLI auto (issue #203, Claim 8: "retain
+  full control by switching between auto and any specific model at any time"). Auto is not
+  a sticky default — practitioners can delegate routing to auto for routine tasks and
+  switch to an explicit model when task capability requirements exceed what auto's
+  bounded pool provides. For Ch02: recommend the mixed strategy for VS Code usage:
+  use auto for interactive coding, completions, and standard debugging tasks; switch to
+  explicit Opus selection for tasks requiring deep cross-codebase analysis or complex
+  multi-step reasoning where the 0x–1x pool ceiling may be insufficient.
+
+### Claim 8: VS Code auto honors all model policies set by administrators
+
+- **Evidence**: Official changelog states admin policy enforcement.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "Auto honors all model policies set by admins"
+- **Our assessment**: Consistent with CLI auto behavior (issue #203, Claim 7: "honors
+  all administrator model settings"). Enterprise admins who configure model exclusion
+  policies can enable VS Code auto without creating a policy bypass risk — auto narrows
+  its routing pool to the intersection of the 0x–1x tier and admin-permitted models.
+  For Ch05: this confirms that the admin policy layer is consistently enforced across all
+  GitHub Copilot auto surfaces (CLI and VS Code). Teams with compliance requirements
+  around model provider choice can enable auto safely on both surfaces.
+
+### Claim 9: VS Code auto leverages models from multiple model families based on subscription type and policies
+
+- **Evidence**: Official changelog describes the model pool in provider-agnostic terms
+  rather than listing specific model names.
+- **Confidence**: settled (stated in official changelog; specific models not listed)
+- **Quote**: "Auto leverages models from multiple model families, depending on subscription
+  type and policies"
+- **Our assessment**: Unlike the CLI auto announcement (which enumerated specific models:
+  GPT-5.4, GPT-5.3-Codex, Sonnet 4.6, Haiku 4.5), the VS Code announcement does not
+  list the pool members. The provider-agnostic framing ("multiple model families") suggests
+  the VS Code auto pool may include models from both Anthropic and OpenAI families, but
+  the specific members are not documented here. For practitioners who need to know which
+  models their requests may be routed to (e.g., for data residency or provider policy
+  reasons), this source does not answer the question — the VS Code documentation on auto
+  model selection would need to be consulted directly.
+
+### Claim 10: VS Code auto requires no setup — users simply select Auto in VS Code
+
+- **Evidence**: Official changelog states this directly as the getting-started instruction.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "Head to VS Code and choose Auto to get started"
+- **Our assessment**: The zero-configuration requirement lowers the adoption barrier
+  significantly. Unlike explicit model selection (which requires practitioners to develop
+  and maintain a model selection heuristic) or CLI auto (which requires CLI tooling
+  setup), VS Code auto is accessible to any VS Code Copilot user by selecting a menu
+  option. For Ch02: recommend auto as the default IDE model configuration for practitioners
+  who have not yet formed a model selection opinion — it provides task-aware routing,
+  billing efficiency, and cache optimization without requiring any configuration investment.
+
+## Concrete Artifacts
+
+### Routing Architecture (VS Code Auto, May 20, 2026)
+
+```
+GitHub Copilot VS Code — Auto Model Selection Routing
+
+INPUT LAYER:
+  Stream 1: Real-time model availability and reliability
+    - Utilization metrics (per-model load)
+    - Model health metrics (latency, error rates)
+
+  Stream 2: Task content analysis
+    - Reasoning complexity
+    - Code generation complexity
+    - Bug diagnosis difficulty
+    - Tool orchestration needs
+
+OUTPUT: Optimal model selection from the 0x–1x multiplier pool
+
+POOL CONSTRAINT:
+  Models with 0x–1x premium request multipliers ONLY.
+  Specific model names NOT enumerated in this changelog.
+  Pool includes "multiple model families" (OpenAI + Anthropic implied).
+  Opus-tier models (>1x multiplier) are NOT in the VS Code auto pool.
+
+ADDITIONAL OPTIMIZATIONS:
+  - Routes along natural cache boundaries (prompt cache preservation)
+  - Respects admin model policies (pool narrowed by admin restrictions)
+```
+
+### Billing Mechanics for VS Code Auto Mode
+
+```
+Premium request billing under VS Code auto:
+
+  Standard (pinned model):
+    Cost = model_multiplier × 1.0
+    e.g., 1x model = 1.0 premium requests
+
+  Auto mode (paid subscribers):
+    Cost = model_multiplier × 0.9   (10% discount)
+    e.g., 1x model selected by auto = 0.9 premium requests
+
+  Pool ceiling:
+    Models limited to 0x to 1x multipliers.
+    No Opus-tier (>1x) models included regardless of task complexity.
+
+  Additional savings:
+    Cache boundary routing avoids unnecessary cache-related costs
+    (mechanism not specified; amount not quantified in this changelog).
+
+Note: Same 10% discount structure as CLI auto (issue #203).
+```
+
+### VS Code Auto vs. CLI Auto — Routing Comparison
+
+```
+Feature                    VS Code Auto (issue #844)   CLI Auto (issue #203)
+─────────────────────────────────────────────────────────────────────────────
+Task-aware routing         YES (4 task dimensions)     NO (plan/policies only)
+Real-time availability     YES (utilization + health)  YES (rate-limit pressure)
+Model pool constraint      0x–1x multipliers           0x–1x multipliers
+10% billing discount       YES                         YES
+Admin policy enforcement   YES                         YES
+User override              YES (any time)              YES (any time)
+Model transparency         Hover in UI                 CLI output display
+Cache-aware routing        YES (stated)                NOT mentioned
+Setup required             None                        None
+
+Key difference: VS Code auto adds task-content analysis as a routing input.
+CLI auto routes only on resource/cost signals, making it a pure availability
+optimizer. VS Code auto is a hybrid: availability optimizer + capability router
+within the cost-bounded pool.
+```
+
+## Cross-References
+
+- **Corroborates** `docs-github-copilot-cli-auto-model-selection.md` (issue #203, Claims 6, 7,
+  and 8): The 10% billing discount for auto, user ability to switch to explicit model selection
+  at any time, and admin policy enforcement are all identical between VS Code auto and CLI auto.
+  These shared mechanics confirm GitHub applies a consistent platform-wide auto-routing policy
+  framework — billing incentives, governance compliance, and user control — across both surfaces.
+
+- **Extends** `docs-github-copilot-cli-auto-model-selection.md` (issue #203, Claim 2): That
+  source's Claim 2 documented that CLI auto routes based on "plan and policies" and NOT on task
+  type. Its assessment stated: "for practitioners who want task-aware routing, explicit model
+  selection remains the only option. Auto is a reliability and cost optimization, not a
+  capability optimizer." This VS Code announcement is that task-aware routing, but implemented
+  in the auto routing mechanism itself on the VS Code surface. The CLI claim is still accurate
+  for the CLI; what changes is the general guide statement about auto mode — it must now
+  distinguish between surfaces. A complete picture of GitHub Copilot auto routing requires
+  both notes: CLI auto is availability-driven; VS Code auto is task-aware + availability-driven.
+  No contradiction issue is required — the CLI note describes CLI behavior accurately; this
+  note adds VS Code behavior that extends rather than contradicts it.
+
+- **Extends** `docs-github-copilot-cca-cost-efficient-models.md` (issue #818, Claim 3): That
+  source documented GitHub's explicit task-complexity-based guidance for CCA model selection:
+  "pick the right model for the job: a smaller, quicker model for straightforward changes, or
+  a more capable model for complex work." VS Code auto automates this exact decision for the
+  IDE surface — rather than requiring the practitioner to manually select the appropriate tier,
+  VS Code auto evaluates the task and routes to the most appropriate model within the 0x–1x
+  pool automatically. The two sources together show GitHub applying task-complexity-aware
+  selection at two levels: explicit manual selection in CCA (issue #818) and automatic routing
+  in VS Code IDE (this source).
+
+- **Complements** `docs-github-copilot-agent-model-selection.md` (issue #171): That source
+  documents explicit model selection for cloud agents on github.com, requiring practitioners
+  to choose between Sonnet and Opus tiers manually. VS Code auto offers a complementary
+  approach for IDE workflows: delegate the selection decision to the router for routine tasks,
+  while retaining the ability to switch to explicit model choice when needed. Together these
+  two sources define a "delegate vs. decide" spectrum: auto (delegate routing) for interactive
+  IDE workflows; explicit selection (decide at task submission) for cloud agent tasks where
+  the task is well-characterized before launch.
+
+- **Novel**:
+  - First corpus source to document a GitHub Copilot auto-routing implementation that uses
+    task content analysis as a routing input. All prior auto-routing documentation (CLI auto,
+    #203) described routing that is explicitly NOT task-aware. VS Code auto represents a new
+    routing paradigm within the GitHub Copilot platform.
+  - First corpus source to document cache-boundary-aware routing as an explicit cost-optimization
+    mechanism in any GitHub Copilot surface. Prior sources discuss prompt caching at the API
+    level; this is the first to document routing decisions being made to preserve cache state.
+  - First corpus source to document a hover-based model transparency affordance in a GitHub
+    Copilot IDE surface. CLI auto discloses the model in terminal output; VS Code uses hover
+    — a different UX paradigm with different implications for programmatic observability.
+  - The four task evaluation dimensions (reasoning, code generation complexity, bug diagnosis
+    difficulty, tool orchestration needs) are the first documented task taxonomy for auto
+    routing in any GitHub Copilot product. This taxonomy has potential guide value as a
+    framework for thinking about how to categorize IDE tasks by model requirement.
+
+## Guide Impact
+
+### Chapter 02: Harness Engineering / Tooling Landscape
+
+- **Revise CLI auto guidance**: `docs-github-copilot-cli-auto-model-selection.md` Claim 2's
+  assessment ("explicit model selection remains the only option for task-aware routing") is now
+  incomplete — it is accurate for the CLI but not for VS Code. The guide should distinguish
+  the two surfaces explicitly: CLI auto = cost/availability optimizer; VS Code auto = task-aware
+  + cost/availability optimizer within the same 0x–1x pool.
+
+- **VS Code default recommendation**: Recommend VS Code auto as the default Copilot model
+  configuration for practitioners who have not formed an explicit model selection policy. It
+  requires no setup, provides task-aware routing within a cost-bounded pool, and reduces
+  billing costs 10% vs. pinning. Practitioners should only switch to explicit model selection
+  when: (a) they need Opus-tier capability for complex tasks exceeding the 0x–1x pool ceiling,
+  or (b) they want programmatic control over which model processes a specific request.
+
+- **Observability gap for VS Code auto**: Note that VS Code auto's model transparency (hover-
+  based) is not directly capturable for logging, unlike CLI auto (terminal output). Teams that
+  want to build empirical routing datasets across model selection and task outcomes should use
+  the CLI tooling or explicit model selection in CCA rather than VS Code auto for their
+  observability workflows.
+
+### Chapter 04: Model Selection and Cost Management
+
+- **Two-tier auto routing strategy**: Establish a clear two-tier recommendation: (1) Use VS Code
+  auto for all interactive IDE coding tasks — it combines task-aware routing with billing
+  efficiency and cache preservation without any configuration cost. (2) Use CLI auto for CLI-
+  based flows (scripted workflows, harness automation) where rate-limit mitigation is the
+  primary concern and task-type routing is not needed. The two auto modes are optimized for
+  different use cases and should not be treated as interchangeable.
+
+- **Cache-boundary routing as a cost argument for auto**: Add the cache boundary optimization
+  (Claim 5) as an additional cost argument for VS Code auto beyond the 10% multiplier discount.
+  Teams with long interactive sessions may benefit from reduced prompt-cache misses when auto
+  maintains routing consistency for a given context. Quantification not available from this
+  source — recommend testing empirically.
+
+- **Pool ceiling remains the binding constraint**: Even with task-aware routing, VS Code auto
+  cannot escalate to Opus-tier models (>1x multiplier). For tasks that require Opus capability,
+  explicit selection is still required. The guide should document this as "task-aware within
+  budget" — VS Code auto optimizes model fit within the cost floor, not across the full
+  capability range.
+
+### Chapter 05: Team Adoption / Enterprise Governance
+
+- **Consistent admin policy enforcement across surfaces**: VS Code auto and CLI auto both honor
+  admin model policies. Enterprise teams that have configured model exclusion policies can
+  enable auto on both surfaces without creating governance gaps. Document this as a governance
+  property of the auto routing family — admin controls propagate to all auto-routing surfaces.
+
+- **Model provider visibility caveat**: VS Code auto does not disclose specific model names in
+  the pool (unlike CLI auto, which enumerated GPT-5.4, GPT-5.3-Codex, Sonnet 4.6, Haiku 4.5).
+  Organizations with data residency requirements or provider-specific compliance constraints
+  should verify the VS Code auto model pool against their policies before enabling — the
+  "multiple model families" description implies cross-provider routing that may not meet all
+  compliance requirements without further investigation.
+
+## Extraction Notes
+
+1. **Source is short by design (~200 words of primary text)**: All substantive claims are
+   exhausted above. The ten claims cover 100% of the primary announcement content; nothing
+   was skimmed.
+2. **Specific model pool not disclosed**: Unlike the CLI auto announcement (issue #203),
+   which listed specific model names (GPT-5.4, GPT-5.3-Codex, Sonnet 4.6, Haiku 4.5), the
+   VS Code announcement uses provider-agnostic language ("multiple model families"). Claim 9
+   reflects this faithfully. Practitioners should consult the linked GitHub documentation
+   ("our documentation about auto model selection") for the current model list.
+3. **No contradictions filed**: The task-aware routing in VS Code auto does not contradict
+   the CLI auto's non-task-aware routing — they are different implementations for different
+   surfaces. The CLI note's *assessment* (Claim 2: "auto is a reliability and cost
+   optimization, not a capability optimizer") is now incomplete as a general statement, but
+   this is a corpus synthesis issue for the guide, not a factual contradiction between sources.
+   No contradiction issue is required.
+4. **Cache boundary routing mechanism not specified**: "Natural cache boundaries" is a
+   meaningful claim but is not technically elaborated in the changelog. Claim 5 notes this
+   limitation. Do not cite specific cache savings figures — none are given.
+5. **VS Code scope only**: This feature is documented for VS Code specifically. Whether
+   JetBrains, other IDEs, or the github.com web interface receive the same task-aware routing
+   logic is not addressed.


### PR DESCRIPTION
Source note extracted by the Miner agent for #844.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.
