### PR TITLE
source: blog-cursor-cloud-agent-dev-environments (#736)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -1671,5 +1671,18 @@
     "file": "source-notes/blog-thebatch-hermes-openclaw-tml-cybersecurity.md",
     "confidence_overall": "emerging",
     "status": "current"
+  },
+  "blog-cursor-cloud-agent-dev-environments": {
+    "slug": "blog-cursor-cloud-agent-dev-environments",
+    "title": "Development environments for your cloud agents",
+    "source_url": "https://cursor.com/blog/cloud-agent-development-environments",
+    "source_type": "blog-post",
+    "author": "Samantha Whitmore, David Wetterau & Nick Bradford (Cursor)",
+    "date_published": "2026-05-13",
+    "date_extracted": "2026-05-25",
+    "issue": "#736",
+    "file": "source-notes/blog-cursor-cloud-agent-dev-environments.md",
+    "confidence_overall": "emerging",
+    "status": "current"
   }
 }

--- a/source-notes/blog-cursor-cloud-agent-dev-environments.md
+++ b/source-notes/blog-cursor-cloud-agent-dev-environments.md
@@ -1,0 +1,245 @@
+---
+source_url: https://cursor.com/blog/cloud-agent-development-environments
+source_type: blog-post
+title: "Development environments for your cloud agents"
+author: Samantha Whitmore, David Wetterau & Nick Bradford (Cursor)
+date_published: 2026-05-13
+date_extracted: 2026-05-25
+last_checked: 2026-05-25
+status: current
+confidence_overall: emerging
+issue: "#736"
+---
+
+# Development environments for your cloud agents
+
+> Cursor's product announcement of cloud agent dev-environment tooling establishes a concrete four-part framework — multi-repo scoping, Dockerfile-as-code configuration, agent-led environment validation with graceful degradation, and environment-level governance (version history, audit log, scoped egress, isolated secrets) — filling the gap between *where* agents run (deployment) and *what context* agents need to work end-to-end.
+
+## Source Context
+
+- **Type**: blog-post (Cursor product blog, product feature announcement, ~7 min read, published May 13, 2026)
+- **Author credibility**: Samantha Whitmore, David Wetterau & Nick Bradford, writing on the official Cursor blog. This is a vendor product announcement — claims serve a commercial purpose. However, the architecture specifics (build-secret scoping, layer-cache performance, graceful degradation behavior, version-history rollback, audit log, per-environment egress allowlists) and the named practitioner quote from Steven Cheng (Senior Engineering Manager at Amplitude) provide genuine engineering evidence. The multi-repo Slack-triggered workflow described by Cheng is separately corroborated by different Amplitude engineers in `blog-cursor-amplitude-autonomous-pipeline.md`. Treat architectural claims as emerging; treat the Cheng quote as anecdotal practitioner evidence.
+- **Scope**: Covers four feature areas: multi-repo environments, Dockerfile-based configuration (build secrets, layer caching, auto-generation), agent-led environment setup/validation, and environment governance (version history, audit log, scoped egress, isolated secrets). Also includes a forward-looking statement about autonomous environment evolution. Does NOT cover: pricing, performance benchmarks for agent tasks in multi-repo vs. single-repo setups, failure modes for misconfigured environments beyond the graceful degradation mention, integration with CI/CD pipelines, or how environments interact with MCP-accessed external services.
+
+## Extracted Claims
+
+### Claim 1: An agent that cannot run tests, query services, or reach APIs cannot close the loop on its work — making the execution environment a first-class agent capability constraint
+
+- **Evidence**: Opening framing of the blog post, presenting the full dev environment as a prerequisite for end-to-end task completion.
+- **Confidence**: settled (logically necessary — without test execution, agents cannot verify their own outputs; corroborated by the "environment as the product" thesis in `blog-cursor-cloud-agent-lessons.md` and the self-hosted cloud agents motivation in `blog-cursor-self-hosted-cloud-agents.md`)
+- **Quote**: "An agent that can write code but can't run tests, query services, or reach APIs cannot close the loop on its work."
+- **Our assessment**: This is the cleanest statement in the corpus of *why* execution environment quality is an agent capability ceiling, not just an infrastructure concern. It applies equally to cloud agents and local agents. For the guide: this sentence belongs at the top of any section on agent execution environments. The claim reframes "dev environment setup" from an IT concern to a core engineering-quality concern.
+
+### Claim 2: Effective development environments give agents full context on the codebase and organization so they can test and verify their work
+
+- **Evidence**: Explicit product framing describing what a full dev environment needs to provide: cloned repositories, installed dependencies, credentials for internal toolchains, and access to build systems.
+- **Confidence**: emerging (vendor framing; logically consistent with practitioner reports across the corpus)
+- **Quote**: "Effective development environments give agents full context on your codebase and organization, so they can test and verify their work."
+- **Our assessment**: The four components (cloned repos, installed dependencies, internal credentials, build system access) are a concrete checklist for evaluating whether an agent environment is complete. Missing any one of these creates a partial environment where the agent can generate code but cannot validate it. This is the environment equivalent of the context engineering principle: garbage in, garbage out.
+
+### Claim 3: Multi-repo environments allow agents to reason about how a change in one part of the codebase affects others — a prerequisite for meaningful enterprise agent work
+
+- **Evidence**: Product description with a named practitioner testimonial. Steven Cheng (Senior Engineering Manager, Amplitude) describes multi-repo support as the specific feature that makes Cursor Automations "actually useful" for cross-repo investigations.
+- **Confidence**: emerging (vendor description + one named practitioner quote; the multi-repo Slack-triggered workflow is corroborated at the workflow level by different Amplitude engineers in `blog-cursor-amplitude-autonomous-pipeline.md`)
+- **Quote**: "With multiple repos in scope, agents can reason about how a change in one part of the codebase affects others and work across repos to deliver, test, and verify changes."
+- **Our assessment**: The multi-repo constraint is the enterprise analog of the single-context window constraint. An agent operating in a single repo faces the same reasoning gap as a developer who can only see one service in a microservices architecture. The cross-repo reasoning capability is not a luxury — in enterprise microservices organizations, changes frequently need to move in tandem across multiple repositories. An agent confined to one repo will produce incomplete PRs.
+
+### Claim 4: Multi-repo support is what makes Cursor Automations "actually useful" for a large-scale engineering team running autonomous agents across Slack channels
+
+- **Evidence**: Named practitioner quote: Steven Cheng, Senior Engineering Manager at Amplitude, describing real operational use of Cursor Automations across public Slack channels.
+- **Confidence**: anecdotal (single named engineer at a named company; represents Amplitude's specific experience at time of writing)
+- **Quote**: "We run Cursor Automations across public Slack channels at Amplitude. Multi-repo support is what makes them actually useful. An agent can investigate a reported issue, figure out which repos it touches, and open a PR with the fix in the right places with full context."
+- **Our assessment**: The quote establishes a concrete use case: event-driven bug investigation in Slack requires multi-repo awareness to produce PRs in the correct repositories. Without multi-repo support, the agent's Slack→PR pipeline would produce fixes only in whichever single repo happened to be in scope. The multi-repo, Slack-triggered investigation workflow described in this quote is separately corroborated by different Amplitude engineers in `blog-cursor-amplitude-autonomous-pipeline.md` (Claim 1: Slack→Linear→PR bug triage pipeline), confirming this as an operational pattern at Amplitude, not a one-person claim.
+
+### Claim 5: Build secrets are scoped to the Dockerfile build step and are not passed to the running agent's environment
+
+- **Evidence**: Explicit security scoping description in the configuration-as-code section.
+- **Confidence**: emerging (vendor-described security design; the principle is consistent with Docker BuildKit secrets semantics, which scope build secrets to build-time only)
+- **Quote**: "Build secrets are scoped to the build step and aren't passed to the running agent's environment."
+- **Our assessment**: This is a concrete security design property that practitioners need when deciding whether to use build secrets for private package registry access. The separation matters: a secret used to pull packages at build time (e.g., a private npm registry token) should not be available to the running agent, which could exfiltrate it through tool calls. The scoping is consistent with Docker's native build-secret model. Teams using private registries can now specify registry credentials without leaking them into the agent's runtime context.
+
+### Claim 6: Layer caching reduces Dockerfile rebuild time by 70% for cache-hitting builds, making iterative environment configuration practical
+
+- **Evidence**: Specific performance metric from the product announcement.
+- **Confidence**: emerging (vendor-reported metric; not independently validated; the principle of layer caching speedup is sound and well-established in Docker infrastructure)
+- **Quote**: "Builds that hit the cache run 70% faster."
+- **Our assessment**: The 70% speedup on cache hits is the operational significance of Dockerfile-based configuration: without caching, every environment rebuild (after a CLAUDE.md change, a dependency update, etc.) would require a full rebuild. With layer caching, only the changed layers rebuild. This makes iterative environment configuration practical — teams can experiment with environment definitions without paying full rebuild costs. The "only the updated layers of your image rebuild when you change the Dockerfile" description is standard Docker behavior, so the 70% figure is the delta from the caching optimization they added, not a general Docker claim.
+
+### Claim 7: Cursor can auto-generate Dockerfiles by inspecting repositories and inferring required tools and dependencies — in private beta for Enterprise teams
+
+- **Evidence**: Product feature description; explicitly marked as private beta rolling out to Enterprise teams.
+- **Confidence**: anecdotal (feature is in private beta; no user reports of quality or accuracy)
+- **Quote**: "Cursor will inspect your repos, figure out the tools and dependencies required, and produce a configuration you can edit and version."
+- **Our assessment**: Auto-generated Dockerfiles address the bootstrapping problem: teams that want Dockerfile-based environments but don't know where to start. The "inspect repos" approach (inferring languages, build tools, test frameworks from the code itself) is the same pattern as `blog-cursor-autoinstall-bootstrapping.md`'s autoinstall mechanism for RL training environments — using the model to understand the repo's toolchain requirements and produce a working environment spec. The output is editable, meaning teams can use the auto-generated file as a starting point and refine it, rather than treating it as a black box.
+
+### Claim 8: Cursor validates environment configuration during setup — flagging missing credentials and asking questions — reducing friction from misconfigured environments
+
+- **Evidence**: Product behavior description in the "Improved agent-led environment setup" section.
+- **Confidence**: emerging (vendor-described UX behavior; no specifics on what is validated or what questions are asked)
+- **Quote**: "As Cursor configures your environment, it will ask you questions, flag missing credentials, and validate that your environment is set up properly."
+- **Our assessment**: Agent-led environment validation is an operationally significant UX pattern: rather than requiring human operators to debug misconfigured environments post-facto (agent fails mid-task because a credential is missing), the system surfaces configuration problems before agent sessions start. This shifts environment debugging from reactive (agent session fails) to proactive (setup wizard surfaces gaps). For teams managing many environments, this reduces the long tail of "agent failed because the environment was broken" incidents.
+
+### Claim 9: On configuration failure, Cursor defaults to a base image with warnings rather than failing completely — preserving agent availability at the cost of reduced capability
+
+- **Evidence**: Explicit product behavior description: failover to base image with "clear warning signs."
+- **Confidence**: emerging (vendor-described failover behavior; no specifics on what "base image" provides or what warnings look like)
+- **Quote**: "If your environment configuration fails, Cursor will default to a base image with clear warning signs so that your cloud agents can keep running instead of immediately failing."
+- **Our assessment**: This graceful degradation behavior represents an explicit design choice: availability over capability. An agent running in a base image can still perform code generation and reasoning, just without specialized tools, internal credentials, or custom dependencies. The "clear warning signs" suggest the design intention is to alert operators to the misconfiguration while keeping agents operationally available. For teams running agent fleets at scale, a Dockerfile misconfiguration should not take all agents offline — the graceful degradation to a known-good base is the correct default.
+
+### Claim 10: Every development environment has its own version history that users can review and roll back, with admin-controlled rollback permissions
+
+- **Evidence**: Product feature description in the governance section.
+- **Confidence**: emerging (vendor-described capability; standard version control principle applied to environment configuration)
+- **Quote**: "Every development environment now has its own version history that users can review and roll back. Admins can also restrict rollback permissions to admins only."
+- **Our assessment**: Environment version history closes the "who broke the environment?" loop. Without it, an environment misconfiguration (e.g., a Dockerfile change that removes a critical dependency) is debugged by comparing the current state to a human's memory of what changed. With version history, operators can see the change, understand its effect, and roll back to a known-good state. Admin-restricted rollback is appropriate for teams where environment stability is a compliance requirement — preventing individual contributors from rolling back production environments without authorization.
+
+### Claim 11: An audit log captures every action team members take on environments, giving security teams full visibility into who changed what
+
+- **Evidence**: Explicit governance feature description.
+- **Confidence**: emerging (vendor-described; standard audit log principle applied to agent environment management)
+- **Quote**: "An audit log captures every action team members take on environments, giving security teams full visibility into who changed what."
+- **Our assessment**: For enterprise agent fleets, the audit log answers the compliance question: "who made what change to the environment, and when?" This is the same audit requirement that applies to production infrastructure (AWS CloudTrail, Kubernetes audit logs), now applied to agent execution environments. Without it, a malicious or accidental environment change (e.g., injecting a compromised dependency, broadening egress allowlists) is invisible to security teams until an incident occurs.
+
+### Claim 12: Egress and secrets can be scoped at the development environment level — enabling fine-grained network access control and secret isolation between environments
+
+- **Evidence**: Product feature description specifying two independent scoping mechanisms.
+- **Confidence**: emerging (vendor-described; logically consistent with network security best practices)
+- **Quote**: "Teams can restrict outbound network access to a specific allowlist for one environment while leaving a different environment more permissive. Additionally, secrets configured for one environment aren't accessible from any other."
+- **Our assessment**: Per-environment egress scoping is the network security analog of least-privilege: an agent working on internal service integrations should only be able to reach those services, not arbitrary internet endpoints. The per-environment secret isolation closes the cross-contamination risk: an agent running in environment A cannot read secrets that belong to environment B, even if both share the same underlying infrastructure. Together, these two controls answer the "how do we prevent an agent from accessing systems it shouldn't?" question at the execution layer.
+
+### Claim 13: The current approach is point-in-time configuration that requires manual rebuilds; the roadmap is toward environments that evolve autonomously as the codebase evolves
+
+- **Evidence**: Forward-looking statement in the "What's next" section.
+- **Confidence**: anecdotal (stated direction; not yet implemented)
+- **Quote**: "Today, environments are configured at a point in time and rebuilt when they fall out of sync with the codebase. We are building towards environment setups that evolve autonomously as your codebase evolves."
+- **Our assessment**: The stated direction is the natural extension of the Dockerfile-as-code pattern: if the environment is defined as code, it can be updated by agents as the codebase changes. A new dependency added to package.json could trigger an environment rebuild automatically. This closes the "environment drift" problem where environments gradually fall out of sync with the codebase they support. The trajectory connects to `blog-cursor-autoinstall-bootstrapping.md`'s pattern of agents configuring their own environments — the difference being that autoinstall targets RL training; this roadmap item targets production agent environments.
+
+## Concrete Artifacts
+
+### Full Dev Environment Requirements (from post intro)
+
+```
+# What cloud agents need to close the loop on engineering tasks
+# Source: "Development environments for your cloud agents" (Cursor, May 2026)
+
+Required components:
+  - Cloned repositories (including multi-repo for cross-codebase work)
+  - Installed dependencies (matching the development toolchain)
+  - Credentials for internal toolchains (private registries, internal APIs)
+  - Access to build systems (test runners, CI tooling, linters)
+
+Without these, the agent cannot:
+  - Run tests to verify its own changes
+  - Query services to confirm API integration
+  - Access internal registries to install dependencies
+  - Use internal tools to validate correctness
+```
+
+### Multi-Repo Environment Configuration (product feature)
+
+```
+# Multi-repo environment configuration (Cursor Cloud Agents, May 2026)
+# Source: "Development environments for your cloud agents"
+
+Capabilities:
+  - Single environment scoped to multiple repositories
+  - Cross-session repo re-use (repos remain cloned between sessions)
+  - Cross-repo change reasoning (agent understands which repos a
+    change touches and can open PRs across all affected repos)
+
+Use case: Enterprise microservices where changes must move in tandem
+  Example: Agent investigates reported issue → determines it touches
+    repos A, B, and C → opens PRs with coordinated fixes in all three
+
+Practitioner evidence (Steven Cheng, Senior Engineering Manager, Amplitude):
+  "An agent can investigate a reported issue, figure out which repos it
+   touches, and open a PR with the fix in the right places with full context."
+```
+
+### Dockerfile Configuration Features (May 2026 release)
+
+```
+# Dockerfile-based environment configuration features
+# Source: "Development environments for your cloud agents" (Cursor, May 2026)
+
+Build secrets:
+  - Scope: build step only; NOT passed to running agent's environment
+  - Use case: private package registry access during dependency install
+  - Security property: secrets not visible to agent at runtime
+
+Layer caching:
+  - Only updated layers rebuild on Dockerfile change
+  - Cache hit speedup: "Builds that hit the cache run 70% faster."
+
+Auto-generation (private beta, Enterprise):
+  - Cursor inspects repos to infer required tools and dependencies
+  - Produces editable Dockerfile as starting point
+  - Rolls out to Enterprise teams in coming weeks (as of May 2026)
+```
+
+### Environment Governance Controls (May 2026 release)
+
+```
+# Environment governance and security controls
+# Source: "Development environments for your cloud agents" (Cursor, May 2026)
+
+Version history:
+  - Per-environment version history: reviewable and rollbackable
+  - Admin can restrict rollback permission to admins only
+
+Audit logging:
+  - "An audit log captures every action team members take on environments,
+     giving security teams full visibility into who changed what."
+
+Egress controls:
+  - Scope: per-environment allowlist for outbound network access
+  - Granularity: one environment can be locked down; another left open
+  - Independent per environment — changes to one don't affect others
+
+Secret isolation:
+  - Secrets scoped per environment
+  - "secrets configured for one environment aren't accessible from any other"
+```
+
+## Cross-References
+
+- **Corroborates**: `blog-cursor-cloud-agent-lessons.md` Claim 1 ("The single biggest factor in cloud agent output quality is ensuring it has a full development environment, like a developer has.") and Claim 2 ("As they've gotten smarter, the environment setup has become the determining factor in whether they execute at their full potential.") — Both posts from Cursor, written by different authors, converge on the same thesis: execution environment quality is the primary cloud agent quality determinant. This source provides the product tooling that operationalizes the principle established by the cloud-agent-lessons post.
+
+- **Corroborates**: `blog-cursor-self-hosted-cloud-agents.md` Claim 1 — That note establishes that enterprise blockers to coding agent adoption are data security and infrastructure access, not model quality. This source provides the specific configuration tooling that addresses the infrastructure-access side of that blocker: multi-repo environments, Dockerfile-based configuration, and per-environment secret/egress controls. Together, the two sources frame the complete enterprise agent environment story: where agents run (self-hosted workers) and what agents run in (configured dev environments with governance).
+
+- **Corroborates**: `blog-cursor-autoinstall-bootstrapping.md` Claim 1 ("if the environment is broken at the start, the model wastes tokens debugging setup instead of learning to solve problems") — That note focuses on RL training environments; this post focuses on production agent environments. Both converge on the same principle: a broken or incomplete environment is not just inconvenient — it eliminates the agent's ability to complete work. The autoinstall post describes automatic environment repair for RL training; this post describes validation-at-setup and graceful degradation for production agents.
+
+- **Extends**: `blog-cursor-self-hosted-cloud-agents.md` — That note documents the deployment architecture (where agents run: self-hosted VMs with outbound-HTTPS-only pattern). This note documents the configuration layer above that (what's inside the VM: repo checkout, dependencies, credentials, network rules, secrets). The two notes compose into a complete picture: deployment architecture handles the "where" and "who can reach what"; environment configuration handles the "what context does the agent have."
+
+- **Extends**: `blog-cursor-cloud-agent-lessons.md` Claim 10 — That source describes multi-repo setups moving from "hardcoded harness behavior" to "agent-controlled via exposed tools." This source is the product announcement of the environment infrastructure (multi-repo environments, Dockerfile config, agent-led setup) that enables that shift. The cloud-agent-lessons note explains the architectural WHY; this note describes the product features WHAT.
+
+- **Extends**: `blog-cursor-amplitude-autonomous-pipeline.md` — That case study describes what Amplitude *does* with cloud agent environments (event-driven triage, cron migrations, 1,000+ automated runs/week). This source documents the specific infrastructure features that make those patterns possible (multi-repo support enables cross-repo PRs; governance controls enable enterprise-safe deployment; Dockerfile config enables reproducible environments across all those runs). Note: the Steven Cheng quote in this post comes from a different Amplitude engineer than the three authors of the amplitude-autonomous-pipeline note (Curtis Liu, Adam Lohner, Spencer Pauly) — this is corroboration at the workflow level across independent sources, not the same person quoted twice.
+
+- **Contradicts**: None identified. This source is additive to the existing Cursor corpus — it documents a configuration and governance layer that was not covered in prior notes.
+
+- **Novel**: The following are not documented in any other source note:
+  - **Per-environment egress allowlists as a named security control**: No other corpus source describes outbound network access control scoped to individual agent environments. This is the first instance of network-layer least-privilege applied to agent execution environments.
+  - **Secret isolation between environments as a named property**: The explicit statement that "secrets configured for one environment aren't accessible from any other" is a new isolation guarantee. Prior notes discuss secret management in agent contexts (e.g., build-time vs. runtime), but not cross-environment isolation as a named property.
+  - **Environment version history + rollback as a governance primitive**: No prior source describes version history for agent environment configurations as a governance mechanism. This is a new category of infrastructure state management.
+  - **Audit logging of environment changes**: No other source in the corpus describes audit logging for agent environment configuration changes as a named security control.
+  - **Auto-generated Dockerfiles via repo inspection**: While `blog-cursor-autoinstall-bootstrapping.md` describes a similar pattern for RL training environments, the product-level feature (Cursor inspecting a repo and producing a Dockerfile) is a new practitioner-facing artifact.
+  - **Graceful degradation to base image**: The explicit failover behavior (broken Dockerfile → base image with warnings, agents keep running) is a new resilience pattern for agent fleet management.
+
+## Guide Impact
+
+- **Chapter 04 (Agent Infrastructure / Environment Configuration)**: This source should anchor any section on configuring cloud agent execution environments. Extract the four-part framework as a named checklist: (1) multi-repo scoping for cross-codebase work, (2) Dockerfile-as-code for reproducible environments, (3) agent-led validation to catch misconfigurations before sessions start, (4) governance controls (version history, audit log, egress allowlists, secret isolation) as enterprise prerequisites. The 70% layer-caching speedup is the concrete evidence for why Dockerfile-based (vs. script-based) configuration matters operationally. The build-secret scoping property (build-time only, not runtime) is a concrete security design choice practitioners must understand when using private package registries.
+
+- **Chapter 02 (Building Agents / Environment as a Design Concern)**: Claim 1 ("An agent that can write code but can't run tests, query services, or reach APIs cannot close the loop on its work") should appear early in any discussion of what makes agent deployments succeed. The execution environment is not an afterthought — it determines whether the agent can produce verified output. Add multi-repo environments as the enterprise analog: a single-repo agent in a microservices org is as constrained as an agent with no test-runner access in a monorepo.
+
+- **Chapter 06 (Enterprise AI Adoption / Governance)**: The four governance controls (version history, audit log, egress allowlists, secret isolation) are the specific features that let enterprise security teams trust agent infrastructure. Chapter 06 currently covers deployment architecture trust (via `blog-cursor-self-hosted-cloud-agents.md`); this source adds the configuration governance layer. The audit log and rollback controls directly address SOC2/SOX-adjacent requirements: "who changed this environment, when, and can we undo it?" should be standard answers for any production agent fleet.
+
+- **Chapter 03 (Safety and Verification / Agent Sandboxing)**: The per-environment egress allowlist and secret isolation are concrete implementations of the "least privilege" principle for agent execution environments. Chapter 03 should reference these as named controls: not just "restrict what agents can access" in principle, but "use per-environment egress allowlists" in practice. The graceful degradation behavior (base image fallback) is also relevant here as a resilience pattern.
+
+## Extraction Notes
+
+- Source is a product announcement blog post — vendor-sourced marketing. The Steven Cheng (Amplitude) practitioner quote is the only external validation. The architectural and security property descriptions (build-secret scoping, egress allowlists, secret isolation) are technically specific enough to treat as genuine product documentation, not just marketing copy. Treat quantitative claims (70% caching speedup) as vendor-reported emerging evidence.
+- The article is a single page with no sub-pages. All content was read from the single URL.
+- The auto-generated Dockerfile feature is explicitly marked as private beta for Enterprise at time of writing (May 13, 2026). Confidence on that specific claim is anecdotal — no user reports or quality assessments exist yet.
+- The "What's next" section (autonomous environment evolution) is forward-looking and should be treated as stated intention, not current capability.
+- No contradictions to file: all claims are additive to the existing corpus. The governance features (version history, audit log, egress, secrets) are new capabilities with no prior corpus source making opposing claims.
+- The previous mining attempt (PR #739) was Assayer-reviewed; the sole accuracy issue was an overclaim that Steven Cheng's quote was "independently documented" in `blog-cursor-amplitude-autonomous-pipeline.md`. That note's authors are Curtis Liu, Adam Lohner, and Spencer Pauly — different Amplitude engineers. The cross-reference in this note has been corrected to reflect workflow-level corroboration, not quote-level duplication. PR #739 was closed due to a pipeline dispatch-rate-limit issue unrelated to note content.


### PR DESCRIPTION
Source note extracted by the Miner agent for #736.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.

## Note on previous attempt (PR #739)

PR #739 was closed by the repo owner due to a pipeline dispatch-rate-limit
issue (commit e8a8935 fixed this). The Assayer had reviewed #739 and found
one accuracy issue in the cross-references section: the note overclaimed that
the Steven Cheng (Amplitude) quote was "independently documented" in
`blog-cursor-amplitude-autonomous-pipeline.md`. That note's authors are
different Amplitude engineers (Curtis Liu, Adam Lohner, Spencer Pauly).

This PR corrects that cross-reference: the Amplitude workflow is corroborated
at the workflow level across independent sources, not the same quote repeated.
The Extraction Notes section documents the fix explicitly. All other content
from the previous extraction (which passed all Assayer checks) is preserved
and updated with today's extraction date.
