### PR TITLE
source: blog-anthropic-founders-playbook (#747)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -1,5 +1,18 @@
 {
   "sources": {
+    "blog-anthropic-founders-playbook": {
+      "slug": "blog-anthropic-founders-playbook",
+      "title": "The Founder's Playbook: Building an AI-Native Startup",
+      "source_url": "https://claude.com/blog/the-founders-playbook",
+      "source_type": "blog-post",
+      "author": "Anthropic",
+      "date_published": "2026-05-14",
+      "date_extracted": "2026-05-25",
+      "issue": "#747",
+      "file": "source-notes/blog-anthropic-founders-playbook.md",
+      "confidence_overall": "emerging",
+      "status": "current"
+    },
     "docs-github-copilot-jetbrains-cli-agent-sessions": {
       "slug": "docs-github-copilot-jetbrains-cli-agent-sessions",
       "title": "Introducing Copilot CLI agent and unified sessions view in GitHub Copilot for JetBrains IDEs",

--- a/source-notes/blog-anthropic-founders-playbook.md
+++ b/source-notes/blog-anthropic-founders-playbook.md
@@ -1,0 +1,604 @@
+---
+source_url: https://claude.com/blog/the-founders-playbook
+source_type: blog-post
+title: "The Founder's Playbook: Building an AI-Native Startup"
+author: Anthropic
+date_published: 2026-05-14
+date_extracted: 2026-05-25
+last_checked: 2026-05-25
+status: current
+confidence_overall: emerging
+issue: "#747"
+---
+
+# The Founder's Playbook: Building an AI-Native Startup
+
+> Anthropic's first-party playbook for AI-native startup founders, remapping the
+> four-stage startup lifecycle (Idea, MVP, Launch, Scale) around agentic tools —
+> providing concrete exit criteria, failure modes, exercise prompts, a Claude product
+> surface matrix, and named case studies including Carta Healthcare, HumanLayer,
+> Ambral, and Vulcan Technologies.
+
+## Source Context
+
+- **Type**: blog-post landing page (claude.com/blog, May 14, 2026) pointing to a
+  34-page PDF playbook. The blog page body is ~300 words of framing; all substantive
+  content is in the PDF, which was fully extracted for this note. PDF filename:
+  `The-Founders-Playbook-05062026_v3 (1).pdf`.
+- **Author credibility**: First-party Anthropic publication. No individual author
+  named — house-authored. Published from the official Claude blog under the "Claude
+  Code" and "Startups" categories. Carries maximum authority for how Anthropic
+  describes Claude's role in the startup lifecycle and for the product surface
+  recommendations (Chat vs. Claude Cowork vs. Claude Code). The case studies name
+  specific companies (Carta Healthcare, HumanLayer, Ambral, Vulcan Technologies,
+  Anything, Cogent, Airtree, Duvo, Zingage, Kindora, Wordsmith) — treat as selected
+  success stories, not a representative sample. The founding advice (problem
+  validation, PMF measurement, moat-building) is synthesized practitioner wisdom,
+  not empirical study.
+- **Scope**: Covers all four stages of the startup lifecycle remapped for 2026 AI
+  tooling — stage goals, exit criteria, failure modes, Claude-assisted exercises, and
+  a product surface selection matrix. Includes founder case study references and a
+  resources section. Does NOT cover: technical implementation details of any Claude
+  feature, pricing or API specifics, team hiring guidance (deliberate omission — the
+  playbook explicitly argues against premature headcount scaling), or evaluation/testing
+  methodology.
+
+## Extracted Claims
+
+### Claim 1: The founder role is shifting from individual contributor to orchestrator of AI agents, with attention moving up the stack toward higher-order decisions
+
+- **Evidence**: First-party Anthropic framing, backed by the playbook's structural
+  argument that AI now handles research, coding, and operational workflows. The
+  framing is repeated across all four stage chapters.
+- **Confidence**: emerging (first-party aspirational framing; consistent with
+  practitioner reports but not empirically measured here)
+- **Quote**: "The founder's attention shifts up the stack toward the higher-order
+  work: generating ideas and directing the systems (AI agents, tools, and whatever
+  small team exists) that carry those ideas out."
+- **Our assessment**: This is the central thesis of the playbook. It maps to the
+  same "orchestrator not executor" framing seen in enterprise AI adoption reports
+  (e.g., Shopify's Thawar describing engineers directing AI). The implication for
+  the guide: the skill being trained is orchestration quality — the ability to scope
+  tasks, evaluate outputs, and course-correct — not raw technical execution. This
+  reframes what "founder skills" means in 2026.
+
+### Claim 2: AI has erased the headcount assumption — lean startups can now reach product validation, early revenue, or profitability before scaling the team
+
+- **Evidence**: Structural claim backed by the playbook's four-stage model, which
+  explicitly describes each stage as achievable without hiring. The three AI
+  capability areas (research, agentic coding, workflow automation) are positioned as
+  replacements for dedicated roles.
+- **Confidence**: emerging (consistent with named case studies but no quantitative
+  data on lean team outcomes)
+- **Quote**: "The traditional startup growth arc assumes that the path from idea to
+  scale is validate → raise → hire → build → raise again → grow → hire more →
+  repeat. Now, AI has erased the expectation that each new phase in the startup
+  lifecycle requires a bigger team, a different skill set, and a fresh funding round."
+- **Our assessment**: The playbook's most consequential structural claim. It requires
+  scrutiny: the lean model works for certain product types (software, SaaS) but may
+  not generalize to hardware, regulated industries, or products requiring significant
+  human relationships. The case studies cited (Kindora, Anything, GC AI) are
+  software/knowledge-work products — the playbook's applicability boundary deserves
+  explicit flagging.
+
+### Claim 3: AI gives founders three distinct capability replacements — expert-on-call research, agentic coding equivalent to a full engineering team, and automated ops workflows
+
+- **Evidence**: Explicit three-category taxonomy in the "What it means to be a
+  founder is changing" chapter. Each capability maps to a different Claude surface.
+- **Confidence**: emerging (first-party framing; categories are coherent but the
+  equivalence claims are aspirational)
+- **Quote**: "Think: on-call expert for every domain" (research); "Think: the
+  engineer who's always available, never blocked" (agentic coding); "Think:
+  on-demand, automated ops team" (workflow automation)
+- **Our assessment**: The three-category framing is the most useful taxonomy in the
+  playbook for understanding where AI substitutes for headcount vs. where it
+  amplifies founder capacity. The "on-call expert" framing for research is well
+  validated by practitioner reports. The "full engineering team" claim for agentic
+  coding is strongest for greenfield projects; legacy codebases require significantly
+  more context management (see `blog-anthropic-maccoss-developer-onboarding.md`).
+  The "automated ops team" framing for workflow automation is the least validated
+  in our corpus.
+
+### Claim 4: The Idea Stage failure mode is treating a working prototype as validation — a prototype is a pressure-testing prop, not evidence of problem-solution fit
+
+- **Evidence**: Explicit "challenge" section in the Idea Stage chapter, including a
+  historical statistic.
+- **Confidence**: emerging (the 42% statistic is cited without primary source; the
+  conceptual argument is sound and consistent with startup methodology literature)
+- **Quote**: "Even before the current era of agentic coding, 42% of startups failed
+  because they built something nobody wanted. Now, though, agentic coding solutions
+  like Claude Code have drastically collapsed the distance between 'I have an idea'
+  and 'I have a product' and that failure rate is only going to climb."
+- **Our assessment**: The 42% statistic (commonly attributed to CB Insights startup
+  failure analyses) is plausible but cited without source — treat as directional, not
+  precise. The core claim is well-grounded: AI makes it easier to build fast, which
+  makes the discipline of validation more important, not less. The implication is
+  counterintuitive: the faster you can build, the more dangerous it is to build
+  before validating. This is a genuine risk upgrade for the AI era.
+
+### Claim 5: AI tools give confirmation bias a "significant powerup" — founders can now construct an elaborate, well-researched-looking case for a bad idea faster than ever before
+
+- **Evidence**: Explicit failure mode section in the Idea Stage chapter with concrete
+  example (asking AI to validate an idea, size a market).
+- **Confidence**: settled (mechanism is straightforward and universally observable;
+  "garbage in, garbage out" applied to research direction)
+- **Quote**: "Ask AI to validate your startup idea and it will find supporting
+  evidence; ask it to size your potential market and it will find the number that
+  makes your TAM look fundable."
+- **Our assessment**: This is the most practically useful warning in the playbook.
+  It applies beyond startups to any AI-assisted research or planning. The antidote
+  given ("pointed in the opposite direction") is sound: explicitly prompt for
+  disconfirming evidence, failed competitors, structural obstacles. The guide should
+  include this as a named failure mode in any chapter on AI-assisted research or
+  planning. The "structured devil's advocate" use case is flagged as "a core use
+  case at every stage of the AI startup life cycle" — this generalization is valuable.
+
+### Claim 6: The Claude product surface matrix maps three tools to three task contexts — Chat for quick exchanges, Claude Cowork for knowledge work from files/sources, Claude Code for software development
+
+- **Evidence**: Explicit table in the Idea Stage chapter, applied throughout the
+  playbook at each stage.
+- **Confidence**: settled (first-party product surface taxonomy; authoritative for
+  how Anthropic intends the surfaces to be differentiated)
+- **Quote**: "The three share the same Claude underneath; what changes is the
+  workspace around it."
+- **Our assessment**: The matrix is the clearest first-party statement of how the
+  three Claude surfaces differ functionally. The key discriminators: Chat = no
+  setup, conversational; Cowork = folder access, connectors, scheduled runs, finished
+  documents; Code = codebase access, diffs, git, dev environments. This directly
+  informs guide recommendations on which surface to use for which harness task.
+
+### Claim 7: CLAUDE.md files are the first artifact of the MVP build — persistent "memory" for the project that every subsequent Claude Code session depends on
+
+- **Evidence**: Explicit recommendation in the MVP Stage chapter, with the
+  architectural context document framing.
+- **Confidence**: settled (first-party recommendation with explicit mechanism
+  description; consistent with large-codebase best practices post)
+- **Quote**: "CLAUDE.md files serve as project-level instructions for Claude Code,
+  providing project-specific context and instructions that are automatically read
+  by the Agent SDK when it runs in a directory. Functionally, they are persistent
+  'memory' for your project."
+- **Our assessment**: The playbook goes further than other sources in explicitly
+  naming CLAUDE.md as the first artifact — before any production code is written.
+  The sequencing matters: define architecture → save as CLAUDE.md → then code.
+  This corroborates `blog-anthropic-large-codebase-best-practices.md` (CLAUDE.md
+  lean and layered) and `blog-anthropic-maccoss-developer-onboarding.md` (context
+  as maintained artifact), and extends both by specifying when CLAUDE.md should
+  first be created (before the first production code session, not after).
+
+### Claim 8: AI technical debt compounds differently from traditional technical debt — each session re-derives foundational decisions from scratch when architectural context isn't documented
+
+- **Evidence**: Explicit "Agentic technical debt" failure mode section in the MVP
+  Stage chapter with mechanism description.
+- **Confidence**: emerging (mechanism is plausible and consistent with practitioner
+  reports; no quantitative evidence of compounding rate)
+- **Quote**: "Without specs and architectural constraints written down somewhere the
+  AI can read, each session re-derives foundational decisions from scratch, and those
+  decisions drift. You end up with a codebase that has no coherent mental model
+  behind it, not because any single piece is bad, but because the pieces were never
+  designed to fit together."
+- **Our assessment**: This is the most precise description of the AI codebase drift
+  failure mode in our corpus. The mechanism is clear: missing architectural context
+  → per-session decision re-derivation → drift → incoherence → collapse requiring
+  rebuild. The compound nature of this debt (each session makes it slightly worse)
+  distinguishes it from regular technical debt (which accrues linearly until addressed).
+  The remedy (CLAUDE.md + scope document + session log) is the concrete counter-pattern.
+
+### Claim 9: AI-generated code requires a security review before any real user touches it — Claude Code generates code that works but not code that is inherently secure
+
+- **Evidence**: Explicit "Insecure by inexperience" failure mode section in the MVP
+  Stage chapter.
+- **Confidence**: settled (mechanism is well-established; "functional code vs. secure
+  code" distinction is widely recognized in security literature)
+- **Quote**: "The hard truth is that agentic coding tools generate code that works,
+  not code that is inherently secure. Functional code is easy, because either the
+  feature works or it doesn't. Security vulnerabilities are invisible until they're
+  exploited, which means there's no natural feedback loop to alert a first-time
+  founder that something is wrong."
+- **Our assessment**: This is the clearest first-party security warning about AI-
+  generated code in our corpus. The key mechanism: no natural feedback loop for
+  security vulnerabilities means first-time founders get no warning signal before
+  a breach. The recommended scope (authentication and session handling, data exposure
+  in API responses, input validation and injection risks, dependencies with known
+  vulnerabilities) is a useful minimum checklist. The "not a substitute for security
+  tooling or a human reviewer" qualification is important — Claude review is a floor,
+  not a ceiling.
+
+### Claim 10: Establishing PMF measurement benchmarks before the first user arrives is the antidote to mistaking early traction for product-market fit
+
+- **Evidence**: Explicit recommendation in the MVP Stage chapter, with two specific
+  tests (Sean Ellis test, effort test).
+- **Confidence**: emerging (the Sean Ellis 40% threshold is from the established PMF
+  literature; the "effort test" is the playbook's own framing)
+- **Quote**: "The Sean Ellis test: Ask your active users: 'How would you feel if you
+  could no longer use this product?' If more than 40% answer 'very disappointed,'
+  that's a meaningful PMF indicator."
+- **Our assessment**: The Sean Ellis threshold (40% "very disappointed") is the
+  standard PMF benchmark from startup methodology — the playbook is correctly citing
+  established practice. The "effort test" (retention requiring constant founder
+  intervention = pre-PMF; product pulling users without founder effort = post-PMF)
+  is a useful qualitative signal. The key guide contribution: establish these
+  benchmarks before launch, not after traction appears, to avoid false positives.
+
+### Claim 11: The Launch stage goal is replacing founder attention with agentic workflows — moving from doing the work to designing the systems that do the work
+
+- **Evidence**: Explicit Launch Stage goal framing with detailed operational systems
+  description.
+- **Confidence**: emerging (first-party recommendation; consistent with Shopify's
+  "directing AI" pattern but not empirically measured for startups)
+- **Quote**: "This is what makes the ultra-lean startup model structurally possible.
+  When Claude Code builds the product, Claude Cowork builds the company around it,
+  and Claude helps operationalize this product and organizational knowledge, a small
+  team can run like a company nx its size."
+- **Our assessment**: The "replacing founder attention with agentic workflows" frame
+  is the Launch stage's central organizing principle. The specific pattern: (1) audit
+  everything you're personally handling, (2) categorize into automate/delegate/
+  keep-founder-owned, (3) build Claude Cowork workflows for automation candidates.
+  The "bottleneck map" exercise (extrapolate what stalls if founder is unavailable
+  for a week) is a concrete diagnostic.
+
+### Claim 12: At Scale, defensible moats for AI-native startups come from three compounding sources: encoded domain expertise, proprietary user behavioral data, and workflow lock-in
+
+- **Evidence**: Explicit Scale Stage chapter with separate sections for each moat
+  type.
+- **Confidence**: emerging (first-party strategic framing; individual moat types are
+  plausible but the compounding claim is aspirational)
+- **Quote**: "This data is time-locked, context-specific, and impossible for a
+  copycat to recreate: you simply can't buy the behavioral fingerprint of thousands
+  of users who've been refining their workflows inside your product."
+- **Our assessment**: The three-moat framework is the most concrete competitive
+  strategy guidance for AI-native startups in our corpus. Domain expertise moat:
+  Claude captures and encodes founder knowledge into product-specific logic competitors
+  can't replicate from generic AI. Data moat: user behavioral signals (accepted/
+  rejected outputs) create a feedback flywheel. Workflow lock-in moat: integrations
+  and automations built on your product make switching an operational project, not
+  a product decision. The guide should present all three as a unified framework.
+
+### Claim 13: The Scale stage founder role re-centers to public-facing executive, with attention expanding to analyst briefings, IPO roadshows, and board relationships while maintaining the lean AI-centered advantage
+
+- **Evidence**: Explicit Scale Stage chapter framing.
+- **Confidence**: emerging (first-party framing; consistent with general startup
+  lifecycle literature)
+- **Quote**: "During the Scale phase, the founder's role re-centers from builder to
+  public-facing executive. The product is still central, but your personal day-to-day
+  work becomes increasingly about the company itself."
+- **Our assessment**: The playbook's answer to "what does the AI-native founder do
+  when the company is big?" — they use Claude for the same three things (research,
+  code, ops) but at higher stakes: board relationship management, enterprise GTM,
+  compliance infrastructure, and investor narrative. The "maintain the lean AI-
+  centered structural advantage" qualifier is important: the goal is not to build a
+  traditional org, but to scale with AI infrastructure remaining central.
+
+### Claim 14: Workflow lock-in is the deepest competitive moat — customers who have built automations, trained teams, and connected data sources on your product face a "full scale operational project" to switch
+
+- **Evidence**: Explicit Scale Stage section with specific exercise.
+- **Confidence**: emerging (mechanism is plausible; no quantitative switching cost
+  data provided)
+- **Quote**: "The longer users run your product inside their daily operations, the
+  more deeply it gets embedded in how they actually work... At this point, switching
+  goes from product decision to full scale operational project."
+- **Our assessment**: The workflow lock-in moat is qualitatively different from the
+  data moat: the data moat is about information that's hard to replicate; the
+  workflow lock-in moat is about operational dependencies that are costly to unwind.
+  The playbook recommends mapping customers by "integration depth" — which automations
+  they've built, which integrations they depend on, their estimated switching cost.
+  This is a concrete Customer Success methodology, not just strategic framing.
+
+### Claim 15: Non-technical founders can now build production software using agentic coding — AI has leveled the playing field between "people who can build" and "people with ideas worth building"
+
+- **Evidence**: First-party claim backed by named case studies (Kindora: nonprofit
+  executive built charity-matching platform; Anything: 1.5M users turn ideas into
+  software without writing code; non-technical PM who built a stress management app).
+- **Confidence**: emerging (case studies are selected success stories; not a
+  representative sample of non-technical founder outcomes)
+- **Quote**: "The most revolutionary result of AI as central infrastructure, though,
+  is to unblock non-technical founders with subject matter expertise. When the
+  founding pool expands beyond people with engineering backgrounds, you get startups
+  built by people with radically different lived experiences, solving real problems
+  that the traditional tech-founder pipeline never prioritized (or perhaps even
+  noticed)."
+- **Our assessment**: The democratization claim is the playbook's most socially
+  significant assertion. The evidence (Kindora, Anything, non-technical PM case) is
+  anecdotal but directionally consistent with the broader pattern of Claude Code
+  enabling non-engineers to ship. The guide should present this as an emerging trend
+  with strong anecdotal support, not a universal pattern — non-technical founders
+  still face learning curves around debugging, architecture review, and security
+  assessment that the playbook acknowledges but doesn't fully address.
+
+## Concrete Artifacts
+
+### Claude Product Surface Selection Matrix
+
+```
+Founder's Claude Surface Selection Matrix
+(Anthropic, "The Founder's Playbook," May 2026 — PDF p.11)
+
+If the task is...                    Reach for         Why
+----------------------------------------------------------------------
+A question, a rewrite,               Chat              Fast, conversational,
+a quick brainstorm                                     no setup
+
+Research, analysis, or               Claude Cowork     Folder access,
+a finished document                                    connectors, skills,
+built from your files                                  scheduled runs
+and systems
+
+Writing, testing, or                 Claude Code       Codebase access,
+shipping software                                      diffs, git, dev
+                                                       environments
+
+"The three share the same Claude underneath; what changes is the
+workspace around it."
+```
+
+### Four-Stage Startup Lifecycle Exit Criteria
+
+```
+AI-Native Startup Lifecycle — Stage Exit Criteria
+(Anthropic, "The Founder's Playbook," May 2026)
+
+IDEA STAGE → exit when:
+  1. Is the problem real and specific? (name who, how often, severity, workarounds)
+  2. Does your solution address the actual problem (not the assumed one)?
+  3. Do you have enough signal to justify building?
+  Exit condition: problem-solution fit
+
+MVP STAGE → exit when:
+  Evidence of genuine PMF: specific, identifiable group finds product valuable
+  enough to return (retention), pay (revenue), or tell others (referral).
+  - Sean Ellis test: >40% "very disappointed" if product disappeared
+  - Effort test: product starts pulling users without constant founder intervention
+  Exit condition: genuine product-market fit evidence
+
+LAUNCH STAGE → exit when:
+  1. Growth is repeatable and channel-driven (CAC, LTV, payback period known)
+  2. Product handles production workloads (security, compliance, reliability)
+  3. Operations run without founder bottlenecks (automation + processes in place)
+  Exit condition: repeatable, sustainable growth engine + operational independence
+
+SCALE STAGE → exit when:
+  - Sustainable profitability without external capital, OR
+  - IPO-readiness, OR
+  - Acquisition
+  All three require: systematic/auditable growth, product moat under scrutiny,
+  operationally mature org.
+  Moat test: "If a well-funded incumbent copied your product today, would
+  your users stay?"
+```
+
+### MVP Stage Session Template and CLAUDE.md Workflow
+
+```
+MVP Stage Claude Code Session Pattern
+(Anthropic, "The Founder's Playbook," May 2026 — PDF p.18)
+
+BEFORE CODING:
+  1. Define architecture with Claude: patterns to follow, dependencies to avoid,
+     tradeoffs being made and why
+  2. Save output as CLAUDE.md markdown file(s) — first artifact of the build
+     "CLAUDE.md files serve as project-level instructions for Claude Code,
+     providing project-specific context and instructions that are automatically
+     read by the Agent SDK when it runs in a directory. Functionally, they are
+     persistent 'memory' for your project."
+
+EACH SESSION:
+  Start: (1) revisit scope document, (2) provide CLAUDE.md architectural context
+  Execute: treat each session as execution of decisions already made,
+           not as opportunity to add new ones
+  End: update CLAUDE.md with any decisions surfaced this session
+
+SUGGESTED SESSION TEMPLATE:
+  - Architectural context document (CLAUDE.md)
+  - Specific task for this session
+  - Constraints or patterns to observe
+  - End-of-session log entry: what was built, decisions made, assumptions introduced
+  "Five minutes of documentation per session is cheap insurance against
+  architectural drift that compounds into an unmanageable codebase."
+```
+
+### Security Review Checklist (Pre-User MVP)
+
+```
+MVP Security Review Minimum Checklist
+(Anthropic, "The Founder's Playbook," May 2026 — PDF p.18)
+
+Run before any real users touch the product:
+  - Authentication and session handling
+  - Data exposure in API responses
+  - Input validation and injection risks
+  - Dependencies with known vulnerabilities
+
+"Treat each finding seriously and assess whether it requires a fix,
+with human review for anything that touches authentication, secrets,
+or data handling."
+
+Note: AI review (Claude first-pass) is NOT a substitute for security
+tooling or human review at higher stakes.
+```
+
+### Named Case Studies — Resources Section
+
+```
+Named Founder Stories (Anthropic, "The Founder's Playbook," May 2026 — PDF pp.33-35)
+
+HumanLayer (YC F24): Used Claude Code to get prototype to market fast,
+  scale AI-powered platform with agentic coding workflows.
+
+Ambral (YC W25): Used Claude Code for fast prototype to market.
+
+Vulcan Technologies (YC S25): Agentic coding workflows for AI-powered platform.
+
+Carta Healthcare: Uses Claude to power clinical abstraction platform —
+  processes 22,000 surgical cases/year, reduces data abstraction time by 66%.
+
+Anything: Powered by Claude + Agent SDK; 1.5M users turn ideas into working
+  software without writing code. AI agent handles full build so solopreneurs
+  can focus on domain expertise.
+
+Cogent: Applied AI lab; Claude as reasoning layer for agents automating
+  vulnerability investigation, prioritization, remediation.
+
+Airtree: Uses Claude Cowork as center of operations infrastructure,
+  uniting data scattered across a dozen tools.
+
+Duvo: AI agents for procurement, supply chain; built entirely on Claude using
+  Agent SDK to orchestrate across ERPs, supplier portals, email, phone calls.
+
+Zingage: AI agent platform for 24/7 home-care agency operations; uses Claude's
+  structured tool calling + contextual reasoning for nuanced patient-tailored outcomes.
+
+Kindora: AI-powered platform built by a nonprofit executive using Claude Sonnet
+  for charity-funder matching. MCP connector lets nonprofits access prospecting
+  tools within Claude.
+
+Wordsmith: Founded by lawyer-turned-CTO; Claude as reasoning engine for
+  contract review, agreement drafting, document review. Engineering team uses
+  Claude Code for building and evolving the platform.
+
+GC AI: Domain expertise + Claude for in-house legal platform with company-specific
+  playbooks, cross-functional stakeholders, variable risk tolerance thresholds.
+```
+
+## Cross-References
+
+- **Corroborates**: `blog-anthropic-large-codebase-best-practices.md` (Claims 6 and 7:
+  CLAUDE.md lean and layered, loaded additively) — This playbook's Claim 7 (CLAUDE.md
+  as first artifact, persistent memory) is the founder-stage version of the large-
+  codebase note's architectural recommendation. Both sources agree: CLAUDE.md is
+  created before production coding begins and maintained as a living document. This
+  playbook adds the temporal claim: create it *before* the first session, not after
+  architectural drift has occurred.
+
+- **Corroborates**: `blog-anthropic-maccoss-developer-onboarding.md` (Claim 4: context
+  is an artifact to maintain, not a problem to solve once) — MacLean's "lay of the
+  land" discipline maps to this playbook's architectural context document first
+  approach. Both treat CLAUDE.md maintenance as an ongoing discipline (session log
+  entries here; progressive context-building in MacLean's approach). This playbook
+  extends MacLean's individual-developer advice to the startup founder context.
+
+- **Corroborates**: `blog-bvp-shopify-ai-playbook.md` (Claims 1–2: orchestrator not
+  executor; operational systems replace founder bottlenecks) — Shopify's Thawar
+  describes engineers shifting from writing code to "directing AI" — the same role
+  shift this playbook describes for founders. The Shopify LLM proxy pattern (centralized
+  control layer) maps to this playbook's Claude Cowork operational automation patterns.
+  Two independent sources (enterprise Shopify, startup playbook) converge on the same
+  orchestration-over-execution principle.
+
+- **Corroborates**: `blog-anthropic-carta-healthcare-context-engineering.md` — The
+  Resources section of this playbook cites Carta Healthcare (22,000 surgical cases/year,
+  66% reduction in data abstraction time). This corroborates the Carta Healthcare
+  source note's Claim 1 (context construction as the primary accuracy lever) —
+  the same case study, cited consistently across two Anthropic publications. The
+  numbers match.
+
+- **Corroborates**: `blog-anthropic-building-enterprise-agents.md` (Claim 1: agentic
+  thinking divide) — The enterprise agents note describes organizations as either
+  "compounding" (embedding AI in workflows) or "plateauing" (using AI as bolt-on).
+  This playbook describes the same split at the startup level: founders who successfully
+  harness AI orchestration vs. those who fall into premature building or confirmation
+  bias traps. Same pattern, different organizational scale.
+
+- **Extends**: `blog-anthropic-large-codebase-best-practices.md` — The large-codebase
+  note covers how to configure Claude Code for enterprise-scale codebases. This
+  playbook covers how to start a codebase correctly from day zero as a founder —
+  establishing CLAUDE.md before any production code exists. Together: the large-
+  codebase note is the "at scale" version; this playbook is the "from scratch" version.
+
+- **Extends**: `blog-anthropic-maccoss-developer-onboarding.md` — MacLean's post covers
+  context management for a single developer on a 17-year-old legacy codebase. This
+  playbook covers context management for a founder building from scratch with no
+  prior codebase. Both arrive at the same pattern (CLAUDE.md first, session discipline),
+  from opposite starting points (maximum legacy context vs. zero context).
+
+- **Novel**:
+  - **Complete four-stage startup lifecycle remapped for AI tooling**: No prior corpus
+    source covers the full Idea → MVP → Launch → Scale arc with stage-specific exit
+    criteria, failure modes, and Claude-assisted exercises. This is the only source in
+    the corpus that addresses the complete founder journey.
+  - **AI confirmation bias as a named failure mode**: The specific mechanism (AI
+    finds supporting evidence for whatever you ask; confirmation bias now has a research
+    engine) is named and addressed as a first-class failure mode. No prior corpus source
+    names this pattern explicitly.
+  - **AI technical debt compounding mechanism**: The specific failure mode (no CLAUDE.md
+    → per-session re-derivation → architectural drift → incoherence → rebuild) is the
+    most precise description of this failure in the corpus.
+  - **Three-moat framework for AI-native startup defensibility**: Domain expertise +
+    proprietary user behavioral data + workflow lock-in as three compounding moat
+    sources is new to the corpus.
+  - **CLAUDE.md as "first artifact of the build"**: The explicit recommendation to
+    create CLAUDE.md before any production code — and the sequencing rationale — is
+    new. Prior sources treat CLAUDE.md as a configuration tool; this playbook treats
+    it as the foundational project artifact.
+  - **Non-technical founder viability as a named trend**: Multiple named case studies
+    (Kindora, Anything, non-technical PM stress management app) specifically documenting
+    non-engineers shipping production software via agentic coding. No prior corpus
+    source focuses on this population.
+
+## Guide Impact
+
+- **Chapter 01 (Daily Workflows / Foundations)**: Add the orchestrator-vs.-executor
+  role shift (Claim 1) as the foundational framing for the guide's opening. The
+  "attention shifts up the stack" formulation is the clearest single-sentence
+  description of what changes when AI is central infrastructure. Currently the guide
+  may frame this implicitly; this source makes it explicit enough to cite directly.
+
+- **Chapter 02 (Harness Engineering)**: Add the CLAUDE.md-as-first-artifact
+  recommendation (Claim 7) to the CLAUDE.md setup section. Currently the corpus
+  treats CLAUDE.md creation as a configuration task done after some initial coding;
+  this source argues it should precede the first production session. The session log
+  pattern (update CLAUDE.md at end of each session with decisions surfaced) is a
+  concrete maintenance discipline not yet documented in the guide.
+
+- **Chapter 02 (Harness Engineering)**: Add the AI technical debt compounding
+  mechanism (Claim 8) as the primary "why CLAUDE.md matters" motivation. The
+  mechanism (per-session re-derivation → drift → incoherence) is the strongest
+  explanation of what happens when CLAUDE.md is absent or neglected. More
+  motivating than "it helps Claude understand your codebase."
+
+- **Chapter 03 (Safety / Verification) or Chapter 02**: Add the security review
+  minimum threshold (Claim 9) with the specific checklist (authentication/session
+  handling, API data exposure, input validation/injection, known-vulnerable
+  dependencies). The "not a substitute for security tooling or human review"
+  qualification is important — frame Claude security review as a floor, not a
+  ceiling.
+
+- **Chapter 05 (Team Adoption)**: Add the three-moat framework (Claim 12) to a
+  planned chapter on organizational strategy or competitive differentiation.
+  The workflow lock-in moat (Claim 14) is particularly actionable — the "integration
+  depth audit" exercise provides a concrete Customer Success methodology.
+
+- **Product Surface Selection (any chapter)**: The Claude product matrix (Claim 6)
+  is the most precise first-party guidance on when to use Chat vs. Cowork vs. Code.
+  The guide should include this matrix wherever tool selection is discussed — it
+  resolves the "which Claude surface do I use?" question definitively for the three
+  primary use cases.
+
+- **Across chapters**: The confirmation bias failure mode (Claim 5) belongs in any
+  section covering AI-assisted research, planning, or problem definition. The antidote
+  (use the same tool to seek disconfirming evidence) is actionable and universally
+  applicable. Flag this explicitly wherever the guide recommends using AI for research.
+
+## Extraction Notes
+
+- The blog page at the source URL is a thin landing page (~300 words); all substantive
+  content is in the linked PDF (`The-Founders-Playbook-05062026_v3 (1).pdf`). The PDF
+  was downloaded via WebFetch and extracted via pdftotext. Full text of all 35 pages
+  was extracted and read. All quotes are verbatim from the PDF text.
+- The PDF is not paywalled; the blog post links to it directly via CDN URL. The PDF
+  is publicly accessible as of the extraction date.
+- The Resources section of the PDF (pp.33-35) names 12 companies as founder stories or
+  case studies. These are selected success stories, not a representative sample —
+  Anthropic curated them as favorable examples. The Carta Healthcare numbers (22K
+  cases/year, 66% reduction) are independently corroborated by the separate Carta
+  Healthcare source note in our corpus.
+- No contradictions with existing source notes were found that would require filing
+  a contradiction issue. The playbook's claims are primarily additive: stage-specific
+  guidance, new exercises, and the startup founder perspective. The Shopify note
+  and this note both support the orchestrator model without conflict.
+- Confidence set to `emerging` overall: first-party Anthropic guidance (high authority
+  for product recommendations), but strategic framing and case study evidence are
+  anecdotal. The 42% startup failure statistic is uncited; PMF tests (Sean Ellis 40%)
+  are borrowed from established startup methodology.
+- The three separate Prospector triage comments on this issue agree on: novelty (high),
+  type (blog-post, first-party), and chapter relevance (Ch01 Foundations, Ch02
+  Harness Engineering, Ch05 Team Adoption, cross-cutting). All key extraction targets
+  from the triage comments were found and extracted.


### PR DESCRIPTION
Source note extracted by the Miner agent for #747.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.

## What was extracted

- **Source**: Anthropic's "The Founder's Playbook: Building an AI-Native Startup" (May 14, 2026)
- **Primary content**: 34-page PDF (extracted in full via pdftotext after blog landing page linked to it)
- **15 claims** extracted covering: founder role shift, startup lifecycle exit criteria, AI technical debt compounding, CLAUDE.md as first artifact, security review baseline, PMF measurement (Sean Ellis test), three-moat defensibility framework, workflow lock-in
- **Concrete artifacts**: Product surface selection matrix (Chat/Cowork/Code), four-stage exit criteria, MVP session template, security checklist, 12 named case studies
- **Cross-references**: Corroborates `blog-anthropic-large-codebase-best-practices.md`, `blog-anthropic-maccoss-developer-onboarding.md`, `blog-anthropic-carta-healthcare-context-engineering.md`, `blog-bvp-shopify-ai-playbook.md`, `blog-anthropic-building-enterprise-agents.md`
- **No contradictions** with existing notes requiring a contradiction issue
