### PR TITLE
source: docs-github-copilot-cca-auto-model-selection (#745)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -1866,5 +1866,18 @@
     "file": "source-notes/docs-ghaw-guides-network-configuration.md",
     "confidence_overall": "emerging",
     "status": "current"
+  },
+  "docs-github-copilot-cca-auto-model-selection": {
+    "slug": "docs-github-copilot-cca-auto-model-selection",
+    "title": "Copilot cloud agent supports auto model selection",
+    "source_url": "https://github.blog/changelog/2026-05-14-copilot-cloud-agent-supports-auto-model-selection",
+    "source_type": "docs",
+    "author": "GitHub (official changelog)",
+    "date_published": "2026-05-14",
+    "date_extracted": "2026-05-25",
+    "issue": "#745",
+    "file": "source-notes/docs-github-copilot-cca-auto-model-selection.md",
+    "confidence_overall": "settled",
+    "status": "current"
   }
 }

--- a/source-notes/docs-github-copilot-cca-auto-model-selection.md
+++ b/source-notes/docs-github-copilot-cca-auto-model-selection.md
@@ -1,0 +1,292 @@
+---
+source_url: https://github.blog/changelog/2026-05-14-copilot-cloud-agent-supports-auto-model-selection
+source_type: docs
+title: "Copilot cloud agent supports auto model selection"
+author: GitHub (official changelog)
+date_published: 2026-05-14
+date_extracted: 2026-05-25
+last_checked: 2026-05-25
+status: current
+confidence_overall: settled
+issue: "#745"
+---
+
+# Copilot Cloud Agent Supports Auto Model Selection
+
+> GitHub's May 14, 2026 announcement extends the Copilot auto model selection
+> feature to the Copilot Cloud Agent surface — the third distinct GitHub Copilot
+> surface (after CLI and VS Code) to receive auto routing — with system-health-
+> and performance-driven routing, a 10% model multiplier discount, and elimination
+> of weekly rate-limit exposure when using auto.
+
+## Source Context
+
+- **Type**: docs (GitHub official product changelog, May 14, 2026; approximately
+  100–150 words of primary announcement text)
+- **Author credibility**: GitHub engineering team announcing a production feature change.
+  Authoritative for the existence of the feature, its stated routing heuristic, and the
+  billing and rate-limit mechanics. Not a credible source for: which specific models are
+  in the auto pool, how the routing algorithm weighs system health vs. model performance
+  signals, whether task complexity is considered, or any comparison of task-outcome quality
+  between auto and pinned model modes.
+- **Scope**: The Copilot auto model selection feature specifically for the Copilot Cloud
+  Agent (CCA) surface — not the CLI, not VS Code, not github.com manual model selection.
+  Covers the routing heuristic (system health + model performance), billing mechanic (10%
+  discount on model multiplier), and rate-limit impact (none for auto users). Does NOT
+  cover: the specific model pool members for CCA auto, whether admin policies constrain
+  the auto pool (likely yes, by analogy with CLI and VS Code auto, but not confirmed in
+  this source), whether the auto pool overlaps with the manual CCA model roster, or any
+  task-success-rate data comparing auto vs. pinned model selection in CCA.
+
+## Extracted Claims
+
+### Claim 1: Copilot Cloud Agent now supports Copilot auto model selection as of May 14, 2026
+
+- **Evidence**: Official GitHub product changelog announcing the feature. The announcement
+  is the product fact — the feature exists and is documented by GitHub engineering.
+- **Confidence**: settled (product fact — the feature exists and is documented)
+- **Quote**: "Copilot cloud agent now supports Copilot auto model selection."
+- **Our assessment**: This is a tooling-landscape addition. Prior to this announcement,
+  CCA required users to explicitly select a model (documented in
+  `docs-github-copilot-agent-model-selection.md`, issue #171, April 14, 2026). CCA now
+  offers two model-selection modes: manual (choose Haiku, Sonnet, or Opus explicitly,
+  per `docs-github-copilot-cca-cost-efficient-models.md`, issue #818, May 18, 2026) and
+  auto (delegate selection to GitHub's routing logic). This is the third GitHub Copilot
+  surface to receive auto routing — following CLI (April 17, issue #203) and preceding VS
+  Code (May 20, issue #844). For Ch02: note that CCA practitioners now have a choice
+  between deliberate model selection and delegated routing, and the guide should articulate
+  when each is appropriate.
+
+### Claim 2: CCA auto routing selects the best available model based on system health and model performance signals
+
+- **Evidence**: Official changelog describes the routing heuristic. The stated criteria are
+  "system health" and "model performance" — operational/availability signals, not task-content
+  analysis.
+- **Confidence**: settled (routing heuristic stated in official changelog)
+- **Quote**: "intelligently selects the best available model based on system health and model
+  performance"
+- **Our assessment**: The CCA auto routing heuristic is availability-and-health-driven, not
+  task-complexity-driven. This distinguishes it from the VS Code auto implementation (issue
+  #844, Claim 1), which evaluates four task dimensions (reasoning, code generation complexity,
+  bug diagnosis difficulty, tool orchestration needs) in addition to utilization and health
+  signals. CCA auto is closer to the CLI auto heuristic (issue #203, Claim 2: "select the most
+  efficient model based on your plan and policies" with rate-limit pressure as the primary
+  signal), but frames its heuristic as "system health and model performance" rather than
+  "plan and policies." The distinction between these framings matters for practitioners:
+  CCA auto optimizes for model availability and health, not for matching model capability to
+  task type. For high-stakes CCA tasks where the complexity of the work should drive model
+  choice, manual model selection remains the appropriate tool. For Ch02: document the
+  routing-heuristic distinction across the three auto surfaces (CLI: plan/policies/rate-limits;
+  CCA: system health/performance; VS Code: task dimensions + availability).
+
+### Claim 3: Using CCA auto grants a 10% discount on the normal model multiplier
+
+- **Evidence**: Billing mechanic stated in official changelog. This matches the identical
+  discount structure documented for CLI auto (issue #203, Claim 6) and VS Code auto (issue
+  #844, Claim 4), confirming it is a platform-wide billing incentive for auto adoption.
+- **Confidence**: settled (billing mechanic stated in official changelog)
+- **Quote**: "a 10% discount on the normal model multiplier"
+- **Our assessment**: The 10% discount is now confirmed across all three GitHub Copilot auto
+  surfaces (CLI, CCA, VS Code). GitHub applies a consistent billing incentive to encourage
+  auto adoption across all surfaces. For Ch04: the 10% auto-mode discount is not surface-
+  specific — it is a platform-wide pricing mechanism. Teams that deploy across CLI, CCA, and
+  VS Code can compound these savings by defaulting to auto on all three surfaces wherever
+  task characteristics allow. However, note from `docs-github-copilot-cca-cost-efficient-models.md`
+  (issue #818, Claim 2) that explicit selection of the 0.33x budget tier (Haiku 4.5) yields
+  a 67% cost reduction vs. Sonnet — a substantially larger lever than the auto-mode 10%
+  discount. For cost-sensitive CCA workloads where task complexity is low, explicit budget-tier
+  selection likely outweighs auto-mode pricing benefits.
+
+### Claim 4: CCA auto users are not impacted by weekly rate limits
+
+- **Evidence**: Rate-limit behavior stated explicitly in official changelog.
+- **Confidence**: settled (stated in official changelog)
+- **Quote**: "won't be impacted by weekly rate limits"
+- **Our assessment**: This is the CCA-specific expression of the rate-limit-mitigation
+  benefit that appears across all GitHub Copilot auto surfaces. For the CLI, the benefit
+  was framed as "dynamic, giving you reliable access to your favorite models while mitigating
+  rate limits" (issue #203, Claim 4). For CCA, the commitment is stronger: users "won't be
+  impacted" — the routing mechanism ensures access remains available regardless of
+  per-model rate-limit pressure. For practitioners who use CCA in production workflows
+  (e.g., automated task delegation via REST API per `docs-github-copilot-cca-rest-api-tasks.md`),
+  this is operationally significant: auto mode eliminates a failure mode that pinned-model
+  workflows would face under heavy load. For Ch02: in harness design for automated CCA
+  invocation, auto mode is the appropriate default when throughput continuity matters more
+  than model-specific capabilities.
+
+### Claim 5: CCA auto is accessed by selecting "Auto" in the model picker
+
+- **Evidence**: Described in the changelog as a user-facing model picker selection. The
+  "Auto" option is a new entry in the existing CCA model picker alongside the manual model
+  options.
+- **Confidence**: settled (access mechanism described in official changelog)
+- **Quote**: (no direct quote; implied by the model picker context described in the changelog)
+- **Our assessment**: The UX model is consistent with VS Code auto ("Head to VS Code and
+  choose Auto to get started," issue #844, Claim 10) — both surfaces add "Auto" as a picker
+  option alongside explicit models. This means existing CCA practitioners do not need to
+  change workflows — they can opt into auto by changing a single picker selection. For
+  Ch02: note that the auto/manual choice in CCA is a per-task decision (at task submission
+  time), consistent with the per-session or per-request nature of auto on other surfaces.
+
+## Concrete Artifacts
+
+### Announcement Summary (May 14, 2026)
+
+```
+Title:     Copilot cloud agent supports auto model selection
+Published: May 14, 2026 12:59:59 +0000
+Source:    https://github.blog/changelog/2026-05-14-copilot-cloud-agent-supports-auto-model-selection
+
+Key facts:
+  Feature:  Copilot auto model selection now available in CCA
+  Routing:  "intelligently selects the best available model based on system
+             health and model performance"
+  Billing:  10% discount on the normal model multiplier
+  Rate limits: Users "won't be impacted by weekly rate limits"
+  Access:   Select "Auto" in the model picker when starting a CCA task
+```
+
+### GitHub Copilot Auto Model Selection — Surface Comparison (as of May 2026)
+
+```
+Surface    | Announced  | Routing Heuristic                          | Pool    | Discount | Rate Limits
+───────────┼────────────┼────────────────────────────────────────────┼─────────┼──────────┼──────────────
+CLI        | Apr 17     | Plan + policies + rate-limit pressure      | 0x–1x   | 10%      | Mitigated
+           | (#203)     | (NOT task-type-aware)                      | (named) |          |
+───────────┼────────────┼────────────────────────────────────────────┼─────────┼──────────┼──────────────
+CCA        | May 14     | System health + model performance          | ?       | 10%      | Eliminated
+           | (#745)     | (NOT confirmed task-type-aware)            | (unspecified)       |
+───────────┼────────────┼────────────────────────────────────────────┼─────────┼──────────┼──────────────
+VS Code    | May 20     | Task dimensions (reasoning, code gen,      | 0x–1x   | 10%      | Mitigated
+           | (#844)     | bug diagnosis, tool orchestration)         | (multi- |          |
+           |            | + utilization + model health metrics       | family) |          |
+
+Note: CCA auto model pool membership is not stated in the May 14 changelog.
+By analogy with other auto surfaces and the CCA manual roster (issue #818),
+the pool likely includes Sonnet-tier and potentially Haiku-tier models, but
+this is not confirmed in this source.
+```
+
+## Cross-References
+
+- **Corroborates** `docs-github-copilot-cli-auto-model-selection.md` (issue #203, Claims 4
+  and 6): The CLI auto announcement documented rate-limit mitigation and a 10% multiplier
+  discount as the primary auto-mode benefits. CCA auto delivers both. The consistent
+  billing incentive (10% discount across CLI, CCA, and VS Code) confirms this is a
+  platform-wide GitHub policy, not a surface-specific experiment. Together, the three auto
+  announcements establish that GitHub's auto-routing economic model is: delegate routing
+  to GitHub → pay 10% less per request, absorb no rate-limit risk.
+
+- **Extends** `docs-github-copilot-agent-model-selection.md` (issue #171): That source
+  (April 14, 2026) documented CCA manual model selection — users choose Sonnet or Opus
+  explicitly when starting a task. This source adds auto as a second selection mode in
+  the same CCA surface. The two sources together give a complete picture of CCA model
+  selection: use explicit selection (issue #171, and expanded by issue #818) when task
+  complexity should drive model choice; use auto (this source) when availability continuity
+  and cost savings matter more than capability-tier control.
+
+- **Extends** `docs-github-copilot-cca-cost-efficient-models.md` (issue #818, May 18,
+  2026): That source expanded CCA's manual model roster to include Haiku 4.5 and
+  GPT-5.4-mini at 0.33x multiplier. This source (May 14, four days earlier) introduced
+  auto mode to CCA. Together they define the full current model-selection surface for CCA:
+  auto mode (system-health routing, 10% discount, no rate-limit risk) plus an expanded
+  explicit model roster spanning three cost tiers (Haiku at 0.33x, Sonnet at ~1x, Opus
+  at >1x). The combination gives practitioners two optimization levers: route automatically
+  for availability/cost, or pin a budget-tier model for maximum cost reduction on simple tasks.
+
+- **Complements** `docs-github-copilot-vscode-auto-model-selection.md` (issue #844, May 20,
+  2026): That source documents VS Code auto, which adds task-complexity-aware routing as a
+  routing input — the first GitHub Copilot auto implementation to evaluate task content.
+  CCA auto (this source) routes on system health and model performance without confirmed
+  task-complexity analysis. The two sources together show that GitHub's auto-routing
+  implementations are not identical across surfaces: VS Code auto is task-aware; CCA auto
+  appears health-and-performance-aware. Practitioners building multi-surface workflows
+  should not assume CCA auto provides the same task-complexity optimization as VS Code auto.
+
+- **Novel**:
+  - First corpus source to document auto model selection for the Copilot Cloud Agent surface
+    specifically. Prior corpus auto-routing sources cover CLI (issue #203) and VS Code
+    (issue #844); CCA is a distinct surface (GitHub-hosted cloud agents, not local IDE tooling
+    or CLI scripts). This completes the picture of GitHub's auto-routing rollout across all
+    three major Copilot surfaces.
+  - The "system health and model performance" routing framing is distinct from both the
+    CLI heuristic ("plan and policies / rate-limit pressure") and the VS Code heuristic
+    ("task dimensions + utilization + health"). CCA auto uses a third framing that does
+    not include confirmed task-complexity analysis. This surface-level routing diversity
+    is new to the corpus.
+  - First source to confirm that CCA auto users "won't be impacted by weekly rate limits" —
+    a stronger guarantee than CLI auto's rate-limit "mitigation." This operational distinction
+    may matter for automated CCA workflows.
+
+## Guide Impact
+
+### Chapter 02: Harness Engineering / Tooling Landscape
+
+- **Three-surface auto routing summary**: The guide should document that GitHub Copilot auto
+  model selection is now available across all three major surfaces: CLI (issue #203), CCA
+  (this source), and VS Code (issue #844). The surfaces differ in their routing heuristics
+  and the guide should distinguish them. Recommended framing: CLI auto = cost/availability
+  optimizer for scripted flows; CCA auto = availability/health optimizer for cloud-agent
+  task delegation; VS Code auto = task-aware + availability optimizer for interactive IDE use.
+
+- **CCA harness design implication**: For teams building automated CCA invocation (via REST
+  API, per `docs-github-copilot-cca-rest-api-tasks.md`), auto mode is appropriate as the
+  default when task throughput continuity is required — it eliminates rate-limit failure
+  modes that pinned-model invocation would encounter under load. Combine with the explicit
+  budget-tier selection pattern (issue #818) for cost-optimized simple-task pipelines.
+
+- **Auto vs. explicit for CCA**: Document the decision heuristic: (1) use auto when task
+  throughput and availability continuity matter and routing to any available model is
+  acceptable; (2) use explicit model selection when task complexity should drive model
+  capability (Haiku for simple bounded tasks, Sonnet for typical multi-file work, Opus for
+  complex reasoning-heavy tasks). Auto and explicit are complementary, not competing.
+
+### Chapter 04: Model Selection and Cost Management
+
+- **Platform-wide 10% auto discount**: The 10% discount for auto is now confirmed across
+  CLI, CCA, and VS Code. Recommend documenting this as a baseline cost-management pattern:
+  default to auto wherever task characteristics allow, across all three surfaces. Teams that
+  can operate on auto for the majority of their Copilot usage compound savings meaningfully
+  at scale.
+
+- **Auto vs. budget-tier explicit selection**: As noted in Claim 3, the 10% auto discount
+  is a smaller lever than the 67% reduction available by explicitly selecting Haiku 4.5
+  (0.33x multiplier) for simple CCA tasks. The guide should clarify: auto-mode savings are
+  availability-driven and cost-secondary; explicit budget-tier selection is cost-primary.
+  For mixed workloads, the optimal strategy may be: use auto for complex tasks (avoiding
+  rate-limit risk, accepting uncertain model tier) and use explicit Haiku selection for
+  well-characterized simple tasks (maximizing cost reduction with acceptable capability).
+
+### Chapter 05: Team Adoption / Enterprise Governance
+
+- **Rate-limit exposure in automated CCA workflows**: Teams running automated CCA workflows
+  should note that auto mode eliminates weekly rate-limit exposure for the CCA surface.
+  This is a governance-relevant property for teams setting usage policies: auto mode is
+  the appropriate default for production CCA integrations where rate-limit-induced failures
+  would have downstream consequences.
+
+## Extraction Notes
+
+1. **Source is very short (~100–150 words of primary announcement text)**: All substantive
+   claims are exhausted in the five claims above. The source is intentionally brief as a
+   GitHub changelog entry.
+2. **Model pool membership not stated**: Unlike the CLI auto announcement (issue #203),
+   which enumerated specific models (GPT-5.4, GPT-5.3-Codex, Sonnet 4.6, Haiku 4.5),
+   the CCA auto announcement does not list the auto pool members. Claim 2 and the Concrete
+   Artifacts table flag this explicitly — do not cite specific CCA auto pool models without
+   a confirming source.
+3. **Admin policy compliance not stated**: The CLI auto note explicitly documented that auto
+   "honors all administrator model settings" (issue #203, Claim 7). The VS Code auto note
+   confirmed the same (issue #844, Claim 8). This CCA auto announcement does not address
+   admin policy compliance. By analogy it is very likely compliant, but this note does not
+   assert it as a confirmed claim.
+4. **Routing heuristic framing differs from other surfaces**: The "system health and model
+   performance" framing is verbatim from the changelog. It is not confirmed whether this
+   includes task-complexity analysis (as VS Code does) or is purely availability-driven
+   (as CLI is). Claim 2 preserves this ambiguity faithfully.
+5. **No contradictions to file**: CCA auto routing on "system health and model performance"
+   does not contradict any existing source note's claim. The CLI auto note (issue #203) and
+   VS Code auto note (issue #844) describe routing on different signals for different
+   surfaces — not the same claim on the same surface. No contradiction issue is required.
+6. **PR 754 was a prior extraction attempt that was closed**: This source note is a fresh
+   extraction for the same issue, on branch miner/issue-745-r26415287299 as specified.


### PR DESCRIPTION
Source note extracted by the Miner agent for #745.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.
