### PR TITLE
source: docs-ghaw-patterns-spec-ops (#353)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -1,5 +1,18 @@
 {
   "sources": {
+    "docs-ghaw-patterns-spec-ops": {
+      "slug": "docs-ghaw-patterns-spec-ops",
+      "title": "GitHub Agentic Workflows: SpecOps Pattern",
+      "source_url": "https://github.github.com/gh-aw/patterns/spec-ops",
+      "source_type": "docs",
+      "author": "GitHub Agentic Workflows team (GitHub Next / Microsoft Research)",
+      "date_published": null,
+      "date_extracted": "2026-05-25",
+      "issue": "#353",
+      "file": "source-notes/docs-ghaw-patterns-spec-ops.md",
+      "confidence_overall": "emerging",
+      "status": "current"
+    },
     "blog-cursor-third-era": {
       "slug": "blog-cursor-third-era",
       "title": "The third era of AI software development",

--- a/source-notes/docs-ghaw-patterns-spec-ops.md
+++ b/source-notes/docs-ghaw-patterns-spec-ops.md
@@ -1,0 +1,444 @@
+---
+source_url: https://github.github.com/gh-aw/patterns/spec-ops
+source_type: docs
+title: "GitHub Agentic Workflows: SpecOps Pattern"
+author: GitHub Agentic Workflows team (GitHub Next / Microsoft Research)
+date_published: null
+date_extracted: 2026-05-25
+last_checked: 2026-05-25
+status: current
+confidence_overall: emerging
+issue: "#353"
+---
+
+# GitHub Agentic Workflows: SpecOps Pattern
+
+> Named pattern for maintaining formal W3C-style specifications via the
+> `w3c-specification-writer` agent, with automatic cross-repository change
+> propagation and compliance test generation — the first corpus entry
+> documenting specification-driven development as an agentic workflow pattern.
+
+## Source Context
+
+- **Type**: docs (official GitHub Agentic Workflows `patterns/spec-ops` page —
+  in the `patterns/` section alongside Agentic Ops, ExpertOps, MultiRepoOps,
+  CentralRepoOps, and Orchestration. Patterns pages are practitioner
+  implementation references, not conceptual overviews or API references.)
+- **Author credibility**: First-party from the GitHub Agentic Workflows team
+  (GitHub Next / Microsoft Research — the same team behind Peli de Halleux's
+  "Agent Factory" blog series, the `gh aw` CLI, and all other `patterns/` pages
+  in the corpus). Claims about pattern design, the `w3c-specification-writer`
+  agent, and the propagation model are authoritative for the `gh aw` platform.
+  The live example (`gh-aw-mcpg`) is an official GitHub Next repository.
+- **Scope**: Covers the SpecOps design pattern: what it does, its four-step
+  workflow, the required W3C specification structure, semantic versioning rules,
+  cross-repository propagation mechanism, and the live MCP Gateway Specification
+  reference implementation. Related links point to MultiRepoOps, Cross-Repository
+  Operations, and Safe Outputs documentation. Does NOT cover: the full
+  `w3c-specification-writer` agent definition, the compliance test generation
+  framework in detail, or the `gh-aw-mcpg` repository internals.
+
+## Extracted Claims
+
+### Claim 1: SpecOps is a named gh-aw pattern for maintaining formal specifications using agentic workflows, with RFC 2119 keywords and automatic propagation to consuming implementations
+
+- **Evidence**: Opening description from the pattern page, confirmed across
+  three independent WebFetch calls with consistent wording.
+- **Confidence**: emerging (first-party documentation; the pattern is formally
+  named and listed in the `patterns/` section, but the platform novelty
+  means operational validation is limited compared to settled patterns)
+- **Quote**: "SpecOps is a pattern for maintaining formal specifications using
+  agentic workflows."
+- **Our assessment**: SpecOps is the corpus's first documented pattern for
+  treating specifications as primary, living artifacts maintained by agents —
+  not as supplementary documentation that lags behind implementation. The W3C
+  framing (RFC 2119 keywords: MUST, SHALL, SHOULD, MAY) is significant: it
+  brings the formal rigor of international standards bodies into software
+  project specification workflows. For Ch02 (Harness Engineering): SpecOps
+  introduces a new workflow trigger type — specification updates — as a
+  first-class harness concern, distinct from code changes, issue triage, and
+  monitoring workflows.
+
+### Claim 2: The pattern uses the `w3c-specification-writer` agent to make specification edits with RFC 2119 keywords, version bumps, and changelog updates
+
+- **Evidence**: The pattern page names the specific agent and its function in
+  the Update step of the workflow. The agent definition is linked from the page.
+- **Confidence**: emerging (first-party naming; the agent definition itself was
+  not fetched as a sub-page — see Extraction Notes)
+- **Quote**: "Edit the specification, either by a local agent or by triggering
+  a workflow like `w3c-specification-writer` to edit the spec document (RFC 2119
+  keywords, version bump, change log)."
+- **Our assessment**: The `w3c-specification-writer` agent is notable for two
+  reasons: (1) it is a named, reusable agent with a specific purpose — not a
+  general-purpose coding agent — suggesting gh-aw is moving toward a library
+  of purpose-built specification agents; (2) the parenthetical "(RFC 2119
+  keywords, version bump, change log)" is the agent's operational scope,
+  confirming that it handles the complete specification authoring workflow in
+  one agent execution. For Ch02: document `w3c-specification-writer` as a
+  purpose-built specification agent — the first corpus example of a
+  domain-specialized agent for formal document authoring (as distinct from
+  code authoring agents).
+
+### Claim 3: The SpecOps workflow has four steps: Update specification → Review PR → Propagate to consuming repositories → Verify compliance via test suite updates
+
+- **Evidence**: The workflow section of the pattern page enumerates all four
+  steps explicitly with bolded step names and concise descriptions. The fourth
+  step (Verify compliance) distinguishes the SpecOps workflow from a simple
+  three-step specification update cycle.
+- **Confidence**: emerging (first-party documentation; the four-step structure
+  is explicitly stated)
+- **Quote**: "Propagate automatically — On merge, workflows detect updates and
+  create PRs in consuming repositories to maintain compliance."
+- **Our assessment**: The four-step loop is architecturally significant:
+  Step 4 (test suite update) closes the specification-implementation gap by
+  ensuring compliance test suites are updated in lockstep with the specification.
+  Without Step 4, a specification could drift ahead of its test coverage.
+  The "on merge" trigger for propagation (Step 3) is the standard gh-aw pattern
+  for event-driven cross-repository coordination — it mirrors the
+  upstream-to-downstream topology documented in `docs-ghaw-multi-repo-ops.md`
+  Claim 5. For Ch04 (Multi-agent orchestration): the SpecOps four-step loop is
+  a concrete multi-workflow coordination chain — spec agent → PR review → merge
+  trigger → propagation workflows → compliance test workflows — spanning both
+  human-in-the-loop (Step 2) and automated steps.
+
+### Claim 4: W3C-style specifications require eight structural components: Abstract, Status, Introduction, Conformance section, numbered technical sections with RFC 2119 keywords, Compliance testing section, References, and Change log
+
+- **Evidence**: The pattern page explicitly lists the required structure for
+  specifications maintained under the SpecOps pattern.
+- **Confidence**: emerging (first-party definition; the list is prescriptive
+  for specs managed by the `w3c-specification-writer` agent in this pattern,
+  not necessarily all W3C documents)
+- **Quote**: "W3C-style specifications require: Abstract, Status, Introduction,
+  Conformance, numbered technical sections with RFC 2119 keywords, Compliance
+  testing, References, and a Change log."
+- **Our assessment**: This structural requirement is the operational definition
+  of a "formal specification" in the SpecOps context. The Conformance section
+  (using RFC 2119 keywords MUST/SHALL/SHOULD/MAY) is what distinguishes a
+  SpecOps-compatible specification from informal documentation: it creates
+  testable, unambiguous requirements. The Change log section enables automated
+  changelog maintenance — the `w3c-specification-writer` agent updates it as
+  part of each specification revision (see Claim 2). For Ch02: teams adopting
+  SpecOps must structure their specifications to this eight-component template
+  before the agent can manage them — the pattern presupposes W3C-style formal
+  structure, not informal wiki documentation.
+
+### Claim 5: Semantic versioning with three levels governs specification updates — Major for breaking changes, Minor for backward-compatible new features, Patch for bug fixes and clarifications
+
+- **Evidence**: The pattern page provides a versioning table with three levels
+  and their triggers. This versioning model is applied by the `w3c-specification-writer`
+  agent as part of the Update step (see Claim 2).
+- **Confidence**: emerging (first-party definition; the version bump logic is
+  the agent's responsibility, so fidelity depends on the agent implementation)
+- **Quote**: (no direct quote; see paraphrase in Our assessment — the versioning
+  table uses "Major (X.0.0)", "Minor (0.Y.0)", "Patch (0.0.Z)" headers with
+  their trigger descriptions)
+- **Our assessment**: The choice of semantic versioning for specifications is
+  architecturally significant: it gives consuming repositories a machine-readable
+  signal about the severity of specification changes. A patch update to a spec
+  might require only test re-runs in consuming repos; a major update signals
+  breaking changes requiring implementation changes before compliance PRs can
+  be merged. The consuming repository workflows that detect spec updates (Step 3)
+  can use the version bump to determine what kind of compliance update to
+  generate. For Ch04: the version bump in the spec PR is the semantic signal
+  that coordinates downstream propagation behavior — it is the protocol between
+  the specification repository and its consumers.
+
+### Claim 6: Cross-repository propagation creates PRs in consuming repositories automatically upon spec PR merge, implementing an agentic compliance cascade
+
+- **Evidence**: Step 3 of the four-step workflow describes the propagation
+  mechanism. The related links section points to MultiRepoOps and
+  Cross-Repository Operations as the underlying implementation references.
+- **Confidence**: emerging (first-party documentation; the propagation mechanism
+  uses the upstream-to-downstream MultiRepoOps topology, but the specific
+  implementation details for detecting spec merges and triggering downstream PRs
+  are not elaborated on this pattern page)
+- **Quote**: "On merge, workflows detect updates and create PRs in consuming
+  repositories to maintain compliance."
+- **Our assessment**: The "workflows detect updates" phrase is the key
+  implementation hook: some mechanism watches for merges to the specification
+  repository and triggers downstream propagation. In the gh-aw platform, this
+  is likely implemented via `workflow_dispatch` or merge-triggered events using
+  the upstream-to-downstream `target-repo` pattern from `docs-ghaw-multi-repo-ops.md`
+  Claim 5. The "to maintain compliance" framing positions the PRs as conformance
+  obligations, not optional improvements — consuming repositories are expected
+  to keep their implementations aligned with the specification. For Ch04:
+  SpecOps propagation is a concrete multi-repository compliance cascade: the
+  specification repository is the single source of truth; consuming repositories
+  receive automatically generated compliance PRs rather than needing to monitor
+  the spec repository manually.
+
+### Claim 7: The MCP Gateway Specification is the live reference implementation of the SpecOps pattern, maintained by the `layout-spec-maintainer` workflow and implemented in `gh-aw-mcpg`
+
+- **Evidence**: The pattern page explicitly names a live example with the
+  repository location and the workflow responsible for maintaining it.
+- **Confidence**: settled (first-party citation of a named live production
+  system maintained by the same team)
+- **Quote**: "The MCP Gateway Specification is a live example — maintained by
+  the `layout-spec-maintainer` workflow and implemented in gh-aw-mcpg."
+- **Our assessment**: The live example is significant for two reasons: (1) the
+  `layout-spec-maintainer` workflow name suggests a named, purpose-built workflow
+  similar to the `w3c-specification-writer` agent — there may be a family of
+  specification-management agents in the gh-aw agent library; (2) the `gh-aw-mcpg`
+  (MCP Gateway) repository is described as the implementation of the specification,
+  meaning the MCP Gateway's behavior is defined by a formal SpecOps-managed
+  specification. For Ch02: MCP Gateway (`gh-aw-mcpg`) as a SpecOps-managed
+  implementation is the clearest evidence that the SpecOps pattern is production-ready —
+  it manages a specification that governs a production MCP server used by the
+  `gh aw` platform itself.
+
+### Claim 8: Compliance test generation is an automated fourth step in the SpecOps cycle, where test generation workflows update test suites to reflect new specification requirements
+
+- **Evidence**: Step 4 of the four-step workflow describes test suite updates
+  as an automated consequence of specification changes.
+- **Confidence**: emerging (first-party documentation; the test generation
+  mechanism is mentioned but not detailed — it may be a separate workflow
+  triggered after propagation, or part of the consuming repository's compliance PR)
+- **Quote**: "Verify compliance — Test generation workflows update compliance
+  test suites against the new requirements."
+- **Our assessment**: The test generation step is the most automated element
+  of the SpecOps cycle — it implies that compliance tests can be derived from
+  a formal W3C specification automatically. This is architecturally plausible
+  given the RFC 2119 structure: MUST/SHALL requirements can be parsed and
+  mapped to test assertions. The "test generation workflows" phrasing suggests
+  these are dedicated gh-aw workflows (not just scripts), making them subject
+  to the same harness patterns (safe outputs, integrity filtering, concurrency
+  controls) as other production workflows. For Ch03 (Safety and Verification):
+  SpecOps provides an agent-native approach to test coverage maintenance —
+  rather than developers manually updating tests when specs change, the
+  specification change itself triggers test generation. This closes the
+  spec-test drift problem.
+
+## Concrete Artifacts
+
+### Four-Step SpecOps Workflow (from pattern page)
+
+```
+Step 1 — Update specification:
+  "Edit the specification, either by a local agent or by triggering a workflow
+  like [w3c-specification-writer] to edit the spec document (RFC 2119 keywords,
+  version bump, change log)."
+
+Step 2 — Review changes:
+  "Approve the specification pull request."
+
+Step 3 — Propagate automatically:
+  "On merge, workflows detect updates and create PRs in consuming repositories
+  to maintain compliance."
+
+Step 4 — Verify compliance:
+  "Test generation workflows update compliance test suites against the new
+  requirements."
+```
+
+*Source: `https://github.github.com/gh-aw/patterns/spec-ops`, workflow steps section*
+
+### W3C Specification Required Structure (from pattern page)
+
+```
+W3C-style specifications require:
+  1. Abstract
+  2. Status
+  3. Introduction
+  4. Conformance (with RFC 2119 keywords: MUST, SHALL, SHOULD, MAY)
+  5. Numbered technical sections (with RFC 2119 keywords)
+  6. Compliance testing
+  7. References
+  8. Change log
+```
+
+*Source: `https://github.github.com/gh-aw/patterns/spec-ops`, specification structure section*
+
+### Semantic Versioning for Specifications (from pattern page)
+
+```
+Version Level  | Trigger
+-------------- | ----------------------------------------
+Major (X.0.0)  | Breaking changes
+Minor (0.Y.0)  | New features, backward-compatible
+Patch (0.0.Z)  | Bug fixes, clarifications
+```
+
+*Source: `https://github.github.com/gh-aw/patterns/spec-ops`, versioning table*
+
+### Live Reference Implementation (from pattern page)
+
+```
+Pattern: SpecOps
+Live example: MCP Gateway Specification
+  - Specification repository: github.github.com/gh-aw/reference/mcp-gateway/
+  - Maintaining workflow: layout-spec-maintainer
+  - Implementing repository: gh-aw-mcpg (github.com/github/gh-aw-mcpg)
+```
+
+*Source: `https://github.github.com/gh-aw/patterns/spec-ops`, example section*
+
+### Related Documentation Links (from pattern page)
+
+```
+Related:
+  - MultiRepoOps (cross-repository coordination pattern)
+  - Cross-Repository Operations (reference)
+  - Safe Outputs (output permission model)
+```
+
+*Source: `https://github.github.com/gh-aw/patterns/spec-ops`, related links section*
+
+## Cross-References
+
+- **Corroborates**:
+  - `docs-ghaw-multi-repo-ops.md` Claim 5 (upstream-to-downstream topology:
+    "Main repo propagates changes using `create-pull-request` with `target-repo`
+    per downstream"): SpecOps propagation (Step 3: creating compliance PRs in
+    consuming repositories upon spec merge) is a concrete application of the
+    upstream-to-downstream topology. The specification repository is the
+    "upstream"; consuming implementation repositories are the "downstreams". The
+    `target-repo` parameter on `create-pull-request` is the likely implementation
+    mechanism for the compliance PRs.
+  - `docs-ghaw-orchestration-patterns.md` Claim 4 (decision between
+    `dispatch-workflow` and `call-workflow`): SpecOps propagation to multiple
+    consuming repositories likely uses `dispatch-workflow` (async, can fan out
+    to multiple repos). The "workflows detect updates" trigger phrase is
+    consistent with event-driven `dispatch-workflow` fan-out from a merge event.
+  - `docs-ghaw-central-repo-ops.md` Claim 1 (Orchestrator+Worker pattern:
+    "where to operate" vs "how to operate"): The SpecOps propagation step
+    implements a variant of this: the specification repository acts as the
+    orchestrator (decides what changed and what compliance changes are needed),
+    while per-consuming-repo workflows act as workers (execute the compliance
+    update for their specific repository).
+
+- **Extends**:
+  - `docs-ghaw-multi-repo-ops.md`: That note documents the MultiRepoOps pattern
+    in general (three topology archetypes, `target-repo` safe-output parameter,
+    authentication). SpecOps is a specific, named application of the
+    upstream-to-downstream topology for specification-driven compliance
+    propagation. The SpecOps pattern page explicitly links to MultiRepoOps as a
+    related reference, confirming the relationship.
+  - `docs-ghaw-orchestration-patterns.md`: That note covers the orchestrator/worker
+    fan-out model and the two dispatch mechanisms. SpecOps uses these primitives
+    for specification change propagation — the spec repository is the
+    orchestrator, consuming repositories are workers. This note extends the
+    orchestration reference with a concrete domain application (specification
+    maintenance).
+  - `docs-ghaw-agentic-ops.md`: That note covers the Agentic Ops pattern
+    (monitoring/auditing agents that inspect other workflows). SpecOps is
+    complementary in the patterns taxonomy: Agentic Ops observes agent fleet
+    health; SpecOps maintains formal specifications that govern agent and system
+    behavior. Together they populate the `patterns/` section with distinct
+    operational archetypes — monitoring vs. specification management.
+
+- **Contradicts**: None identified. SpecOps is the first corpus entry for
+  W3C specification maintenance workflows. No existing source note makes claims
+  that conflict with the SpecOps pattern's design, the `w3c-specification-writer`
+  agent, or the propagation model. No contradiction issue required.
+
+- **Novel**:
+  - **SpecOps as a named specification-maintenance pattern** (Claim 1): No
+    existing corpus source documents a pattern for treating specifications as
+    first-class, agent-maintained artifacts. All prior corpus sources treat
+    specifications as supplementary documentation or as informal requirements;
+    none introduces a formal W3C-style specification as a living document in an
+    agentic workflow cycle.
+  - **The `w3c-specification-writer` purpose-built specification agent** (Claim 2):
+    No existing corpus source documents a purpose-built, named agent for formal
+    document authoring. Prior agents in the corpus are general-purpose coding
+    agents (Copilot, Claude) or role-specific workflow agents (audit, optimize,
+    monitor). A dedicated specification-authoring agent is a new category.
+  - **Four-step spec-driven compliance loop** (Claim 3): The Update → Review →
+    Propagate → Verify loop, with a human-in-the-loop PR review as Step 2, is
+    a new workflow topology in the corpus. It combines human review, automated
+    propagation, and automated test generation in a single coordinated cycle.
+  - **W3C eight-component specification structure as an agent input requirement**
+    (Claim 4): The corpus does not document structural requirements for agent-
+    maintained documents anywhere. The eight-component structure (with RFC 2119
+    keywords) is the first formal document schema in the corpus.
+  - **Semantic versioning applied to specifications** (Claim 5): While semantic
+    versioning for software is mentioned in other corpus sources, applying
+    semantic versioning as a first-class concept to a specification document —
+    where the version bump is determined by the agent and drives downstream
+    propagation behavior — is not documented anywhere in the corpus.
+  - **Compliance test generation as a harness workflow** (Claim 8): The idea
+    that specification changes automatically trigger test suite updates via
+    dedicated "test generation workflows" is novel to the corpus. No existing
+    source describes test generation as an agentic workflow responsibility.
+  - **`layout-spec-maintainer` as a second named specification-maintenance
+    workflow** (Claim 7): The live example names both `w3c-specification-writer`
+    (editing agent) and `layout-spec-maintainer` (maintaining workflow) as
+    separate named agents — suggesting a taxonomy of spec-maintenance agents.
+    Neither is documented anywhere else in the corpus.
+
+## Guide Impact
+
+- **Chapter 02 (Harness Engineering)**:
+  - Add SpecOps as a named pattern for specification-driven development in the
+    patterns taxonomy, alongside Agentic Ops, ExpertOps, MultiRepoOps, and
+    CentralRepoOps. SpecOps is the harness pattern for teams that maintain
+    formal specifications that multiple repositories must implement.
+  - Document the `w3c-specification-writer` agent as the purpose-built entry
+    point for SpecOps adoption — teams that want to adopt the pattern start
+    by installing this agent and structuring their specification to the eight-
+    component template.
+  - Document the W3C eight-component specification structure as a required
+    template for SpecOps-compatible specifications. Teams cannot adopt SpecOps
+    with informal wiki-style documentation — they must first formalize their
+    specifications.
+
+- **Chapter 04 (Multi-agent orchestration — Propagation Workflows)**:
+  - Add SpecOps propagation as a concrete example of the upstream-to-downstream
+    MultiRepoOps topology applied to specification compliance. The spec PR merge
+    event is the orchestration trigger; compliance PR creation in consuming
+    repositories is the worker action. Cross-reference `docs-ghaw-multi-repo-ops.md`
+    Claim 5 for the `target-repo` implementation mechanism.
+  - Document semantic versioning of specifications as a machine-readable signal
+    for downstream propagation behavior: patch updates may trigger test re-runs
+    only; major updates signal breaking changes requiring implementation work.
+    The version bump is the protocol between the spec repository and its consumers.
+
+- **Chapter 03 (Safety and Verification)**:
+  - Add compliance test generation (Step 4) as an agent-native approach to
+    spec-test drift prevention. When specifications change, test generation
+    workflows update compliance tests automatically. This is a new category of
+    safety mechanism in the corpus: specification-driven test maintenance.
+
+- **Chapter 05 (Team Adoption — When to adopt SpecOps)**:
+  - Document SpecOps as the appropriate pattern when: (a) multiple repositories
+    must implement a shared formal specification, (b) the specification changes
+    frequently enough that manual propagation is impractical, (c) compliance
+    testing coverage must be maintained in sync with the specification. The
+    MCP Gateway (`gh-aw-mcpg`) example provides the concrete adoption reference.
+
+## Extraction Notes
+
+1. **WebFetch processes content through an AI model**: The `gh-aw/patterns/spec-ops`
+   page content was returned by the WebFetch tool's AI model. Three independent
+   WebFetch calls were made with different prompts to triangulate and cross-check
+   the content. Claims and quotes are drawn from text that appeared consistently
+   across calls and was returned in the same form. The Assayer should spot-check
+   all quoted passages against the source URL, as minor wording variations from
+   the source page are possible with AI-processed fetch results.
+
+2. **The `w3c-specification-writer` agent sub-page was not fetched**: The pattern
+   page links to the agent's definition file in the GitHub repository
+   (`github.com/github/gh-aw/blob/main/.github/agents/w3c-specification-writer.agent.md`).
+   This sub-page was not fetched per the 5-page limit in MINER.md §1 (the agent
+   definition is not part of the pattern documentation itself). A dedicated source
+   note on this agent definition would add significant depth to Claim 2.
+
+3. **The `gh-aw-mcpg` reference implementation was not fetched**: The live example
+   repository (`github.com/github/gh-aw-mcpg`) was not fetched. It may contain
+   concrete workflow YAML for the propagation and compliance test generation steps
+   (Steps 3 and 4). This is the highest-value sub-page not covered in this note.
+
+4. **No explicit "When to use" section found**: Unlike most `patterns/` pages
+   (e.g., Agentic Ops which has a "Use this pattern when..." section), the SpecOps
+   page does not appear to have an explicit applicability condition section. The
+   adoption criteria in Guide Impact (Ch05) are inferred from the pattern description.
+
+5. **Four-step workflow vs. three-step summary**: Earlier WebFetch calls returned
+   a three-step summary of the workflow (Update → Review → Propagate). A
+   more targeted third WebFetch call confirmed a fourth step (Verify compliance —
+   test generation). The four-step version is treated as authoritative.
+
+6. **No contradictions to file**: Reviewed all existing GHAW corpus source notes.
+   SpecOps is the first corpus entry for specification maintenance workflows —
+   no existing source claims conflict with any claim in this note. No contradiction
+   issue required.


### PR DESCRIPTION
Source note extracted by the Miner agent for #353.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.
