### PR TITLE
source: docs-github-copilot-cca-fix-failing-actions-pro-max (#1110)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -2594,5 +2594,18 @@
     "file": "source-notes/blog-anthropic-sires-gtm-claude-code.md",
     "confidence_overall": "anecdotal",
     "status": "current"
+  },
+  "docs-github-copilot-cca-fix-failing-actions-pro-max": {
+    "slug": "docs-github-copilot-cca-fix-failing-actions-pro-max",
+    "title": "Fix with Copilot for failing Actions now in Pro, Pro+, and Max",
+    "source_url": "https://github.blog/changelog/2026-06-04-fix-with-copilot-for-failing-actions-now-in-pro-pro-and-max",
+    "source_type": "docs",
+    "author": "GitHub (official changelog)",
+    "date_published": "2026-06-04",
+    "date_extracted": "2026-06-08",
+    "issue": "#1110",
+    "file": "source-notes/docs-github-copilot-cca-fix-failing-actions-pro-max.md",
+    "confidence_overall": "settled",
+    "status": "current"
   }
 }

--- a/source-notes/docs-github-copilot-cca-fix-failing-actions-pro-max.md
+++ b/source-notes/docs-github-copilot-cca-fix-failing-actions-pro-max.md
@@ -1,0 +1,287 @@
+---
+source_url: https://github.blog/changelog/2026-06-04-fix-with-copilot-for-failing-actions-now-in-pro-pro-and-max
+source_type: docs
+title: "Fix with Copilot for failing Actions now in Pro, Pro+, and Max"
+author: GitHub (official changelog)
+date_published: 2026-06-04
+date_extracted: 2026-06-08
+last_checked: 2026-06-08
+status: current
+confidence_overall: settled
+issue: "#1110"
+---
+
+# Fix with Copilot for Failing Actions Now in Pro, Pro+, and Max
+
+> GitHub's June 4, 2026 changelog expanding the "Fix with Copilot" CCA feature from
+> Business/Enterprise-only (May 18, 2026) to individual plans — Pro, Pro+, and Max —
+> making one-click CI failure delegation available to a substantially broader
+> subscriber base while keeping feature behavior and scope unchanged.
+
+## Source Context
+
+- **Type**: docs (GitHub official product changelog, ~100-word announcement,
+  June 4, 2026; one linked "Starting GitHub Copilot sessions" documentation page
+  referenced but not uniquely fetched for this note)
+- **Author credibility**: GitHub engineering team announcing a production feature
+  expansion. Authoritative for: the tier expansion (Pro, Pro+, Max now included),
+  the feature behavior, and the stated use-case scope. Not authoritative for:
+  whether the admin-enablement prerequisite from May 18 applies to individual plan
+  users; what "Copilot Max" is as a plan tier (not defined in this changelog);
+  which failure types CCA can reliably handle vs. decline; billing implications.
+- **Scope**: Covers the tier access expansion announcement. Does NOT cover: details
+  on "Copilot Max" plan capabilities; whether individual plan users need any admin
+  configuration to access this feature; behavior on failure types outside "simple"
+  (tests, linters); Actions minutes + AI Credits billing.
+
+## Extracted Claims
+
+### Claim 1: "Fix with Copilot" for failing Actions is now available to Copilot Pro, Pro+, and Max subscribers — expanding access from the original Business/Enterprise-only restriction
+
+- **Evidence**: Official GitHub product changelog announcing the tier expansion as
+  live. The May 18 entry restricted the feature to "Copilot Business and Copilot
+  Enterprise subscribers." The June 4 entry opens the same feature to "Copilot Pro,
+  Pro+, and Max subscribers." Seventeen days elapsed between the two announcements.
+- **Confidence**: settled (explicit tier expansion in official product changelog,
+  framed in present-tense as a current change)
+- **Quote**: "When a GitHub Actions job fails, Copilot Pro, Pro+, and Max subscribers
+  can now ask Copilot cloud agent to fix it in one click."
+- **Our assessment**: This is the sole new claim of the June 4 entry — a tier access
+  expansion, not a new feature. The feature behavior, scope, and execution model are
+  unchanged from May 18 (see `docs-github-copilot-cca-fix-failing-actions.md`); the
+  only change is which subscribers can access it. The practical impact is significant:
+  Pro, Pro+, and Max are individual subscription tiers (vs. Business/Enterprise which
+  are org/enterprise-level plans), meaning individual developers — not just org or
+  enterprise users — can now use "Fix with Copilot" for failing Actions. For Ch05
+  (Team Adoption): the recommendation to adopt this feature no longer requires a
+  Copilot Business or Enterprise subscription. Individual developers on Pro, Pro+, or
+  Max can use it directly. `docs-github-copilot-cca-fix-failing-actions.md` Claim 1
+  established "Copilot Business and Enterprise" as the access requirement; this source
+  supersedes that restriction by adding the individual plan tiers.
+
+### Claim 2: The feature behavior and UX are unchanged from the May 18 announcement — one-click invocation from workflow run logs, CCA investigates, pushes fix, tags for review from its cloud-based environment
+
+- **Evidence**: The June 4 changelog body uses verbatim-identical description to
+  May 18 for the CCA behavior: investigate → push fix → tag for review, from a
+  cloud-based development environment. This is the same text reused, not new claims.
+- **Confidence**: settled (feature behavior described in official announcement;
+  verbatim match with May 18 confirms no behavioral change)
+- **Quote**: "Click the Fix with Copilot button on the workflow run logs page, and
+  Copilot will investigate the failure, push a fix to your branch, and tag you for
+  review when it's done. It does all this from its own cloud-based development
+  environment."
+- **Our assessment**: The June 4 changelog is a tier-access announcement, not a
+  feature-change announcement. All other claims in `docs-github-copilot-cca-fix-failing-actions.md`
+  about the execution model, ephemeral environment, self-verification capability,
+  human review gate, PR-branch scoping, and CCA structural constraints continue to
+  apply to Pro/Pro+/Max users. The Concrete Artifacts and Guide Impact in the May 18
+  note remain correct and are not superseded by this source, only extended by it.
+
+### Claim 3: The "simple but time-consuming" scope characterization (tests, linter failures) is repeated verbatim and unchanged for the Pro/Pro+/Max expansion
+
+- **Evidence**: The June 4 changelog explicitly restates the same scope framing as
+  May 18 word-for-word.
+- **Confidence**: settled (verbatim restatement in official announcement)
+- **Quote**: "This means you can hand off simple but time-consuming work to Copilot
+  (e.g., fixing tests or correcting linter failures) and stay focused on what you
+  actually want to build."
+- **Our assessment**: The scope constraint applies equally to Pro/Pro+/Max users.
+  Individual plan users should have the same reliability expectations as Business/
+  Enterprise users: the feature is designed for deterministic, verifiable failures
+  (lint, formatting, straightforward test assertions). Complex failures (logic errors,
+  infrastructure, flaky tests) remain outside the stated scope. No evidence in the
+  June 4 entry that CCA's capability changed alongside the access expansion.
+
+### Claim 4: The June 4 changelog omits the admin-enablement prerequisite present in the May 18 announcement, consistent with individual plans having no organizational admin layer
+
+- **Evidence**: The May 18 changelog explicitly stated: "If your organization hasn't
+  enabled Copilot cloud agent yet, an administrator will need to turn it on before you
+  can start delegating to Copilot." The June 4 changelog does not include this paragraph.
+  Individual plan subscribers (Pro, Pro+, Max) subscribe directly without an organizational
+  admin intermediary.
+- **Confidence**: emerging (absence of text is weak evidence; linked documentation may
+  address this — Assayer should verify against the live "Starting GitHub Copilot sessions"
+  documentation page linked from the June 4 entry)
+- **Quote**: (no direct quote; the relevant claim is the *absence* of the admin
+  prerequisite text that appeared in the May 18 entry for Business/Enterprise)
+- **Our assessment**: For org-tier plans (Business, Enterprise), CCA is disabled by
+  default and requires admin enablement (see `docs-github-copilot-cca-fix-failing-actions.md`
+  Claim 5). For individual plans (Pro, Pro+, Max), no organizational admin exists. The
+  omission of the admin paragraph from the June 4 entry likely reflects this structural
+  difference: individual users can access CCA directly without waiting for an admin to
+  enable it. If confirmed, this meaningfully reduces adoption friction for individual
+  practitioners relative to Enterprise users. For Ch05: team adoption guidance should
+  distinguish the admin-enablement path (Business/Enterprise) from the likely self-service
+  access (Pro/Pro+/Max). Practitioners advising individual developers on this feature
+  should not require them to contact an org admin.
+
+### Claim 5: "Copilot Max" is referenced as a peer to Pro and Pro+ in the June 4 expansion, appearing as a current GitHub Copilot individual subscription tier not documented in prior corpus notes
+
+- **Evidence**: The June 4 entry names "Copilot Pro, Pro+, and Max subscribers" as
+  the access group. "Max" is listed alongside Pro and Pro+ without further definition.
+  The April 20 individual plan changes note (`docs-github-copilot-individual-plan-changes.md`)
+  covered Free, Pro, Pro+, and Student — no "Max" tier appeared there. The tier name
+  pattern (Pro < Pro+ < Max by implication) suggests Max is a higher individual tier.
+- **Confidence**: emerging (tier name is referenced in official changelog; plan
+  capabilities, pricing, and relationship to Pro+ are not defined in this entry)
+- **Quote**: "Copilot Pro, Pro+, and Max subscribers can now ask Copilot cloud agent
+  to fix it in one click."
+- **Our assessment**: "Copilot Max" is a named individual subscription tier in GitHub's
+  current plan lineup as of June 4, 2026. It was not documented in the April 20 individual
+  plan changes note (which covered only Free, Pro, Pro+, Student). Its appearance here
+  alongside Pro and Pro+ suggests it was either introduced or became prominent after April
+  20. Guide content that describes GitHub Copilot individual plan tiers should include Max
+  alongside Pro and Pro+. A dedicated source note for Copilot Max tier capabilities and
+  pricing would be needed to fully document the individual plan access landscape.
+
+## Concrete Artifacts
+
+### Verbatim Text of Source Changelog (June 4, 2026)
+
+```
+Title: Fix with Copilot for failing Actions now in Pro, Pro+, and Max
+Published: June 4, 2026
+
+When a GitHub Actions job fails, Copilot Pro, Pro+, and Max subscribers can now
+ask Copilot cloud agent to fix it in one click.
+
+Click the Fix with Copilot button on the workflow run logs page, and Copilot will
+investigate the failure, push a fix to your branch, and tag you for review when
+it's done. It does all this from its own cloud-based development environment.
+
+This means you can hand off simple but time-consuming work to Copilot (e.g.,
+fixing tests or correcting linter failures) and stay focused on what you actually
+want to build.
+
+[Reference to "Starting GitHub Copilot sessions" documentation — exact text
+of the final sentence not captured verbatim in WebFetch]
+```
+
+Source: https://github.blog/changelog/2026-06-04-fix-with-copilot-for-failing-actions-now-in-pro-pro-and-max
+Retrieved: 2026-06-08 via WebFetch (two fetches; body quotes consistent across both)
+
+### Feature Access Tier Summary — "Fix with Copilot" for Failing Actions (Updated June 4, 2026)
+
+```
+Feature: Fix with Copilot for Failing GitHub Actions
+Original announcement: 2026-05-18 (Business/Enterprise)
+Tier expansion:        2026-06-04 (Pro, Pro+, Max added)
+
+Access eligibility (as of June 4, 2026):
+  ✅  Copilot Pro subscribers          [added June 4, 2026]
+  ✅  Copilot Pro+ subscribers         [added June 4, 2026]
+  ✅  Copilot Max subscribers          [added June 4, 2026]
+  ✅  Copilot Business subscribers     [original — May 18, 2026]
+  ✅  Copilot Enterprise subscribers   [original — May 18, 2026]
+  ❌  GitHub Actions alone (subscription required)
+
+Admin prerequisite:
+  Business/Enterprise: Org admin must enable CCA (disabled by default)
+    → Source: docs-github-copilot-cca-fix-failing-actions.md Claim 5
+  Pro/Pro+/Max:  Admin prerequisite NOT mentioned in June 4 announcement
+    → Individual plans have no organizational admin layer
+    → Assayer: verify against "Starting GitHub Copilot sessions" docs
+
+Trigger condition, entry point, behavior, scope, constraints:
+  Unchanged from May 18 — see docs-github-copilot-cca-fix-failing-actions.md
+  Concrete Artifacts for the complete feature summary (PR-branch scope,
+  two-step user procedure, ephemeral environment, human review requirement).
+```
+
+## Cross-References
+
+- **Corroborates**:
+  - `docs-github-copilot-cca-fix-failing-actions.md` Claim 2 ("Clicking 'Fix with
+    Copilot' causes CCA to investigate the failure, push a fix to the branch, and tag
+    the user for review — all from its cloud-based development environment"): The June 4
+    entry uses verbatim-identical language for the feature behavior. The execution model
+    (investigate → fix → tag), cloud-based environment, and human review requirement are
+    confirmed unchanged across the tier expansion.
+  - `docs-github-copilot-cca-fix-failing-actions.md` Claim 3 ("The feature is scoped to
+    'simple but time-consuming' failures, with fixing tests and correcting linter failures
+    as the canonical examples"): The June 4 entry repeats the scope characterization
+    verbatim. No scope expansion or contraction alongside the tier expansion.
+
+- **Contradicts**: None. The tier expansion is purely additive. No prior corpus source
+  claims that Pro/Pro+/Max cannot access this feature — the May 18 note documented that
+  Business/Enterprise can access it without excluding individual plans by name. No
+  contradiction issue filed.
+
+- **Extends**:
+  - `docs-github-copilot-cca-fix-failing-actions.md` Claim 1 ("Copilot Business and
+    Enterprise subscribers can now ask Copilot cloud agent to fix a failing GitHub Actions
+    job in one click from the workflow run logs page"): This source directly updates the
+    "who can use this" answer. The access eligibility now includes Pro, Pro+, and Max.
+    The May 18 access tier list remains correct for Business/Enterprise; this source
+    extends it to individual plans.
+  - `docs-github-copilot-individual-plan-changes.md` (April 20 individual plan changes,
+    issue #289): That source documented individual plan tier structure as of April 20,
+    2026 (Free, Pro, Pro+, Student). This source adds "Fix with Copilot" to the list
+    of features available at the individual plan level, and introduces "Max" as a named
+    tier not covered in the April 20 scope.
+
+- **Novel**:
+  - **"Copilot Max" as an individual Copilot plan tier**: No prior corpus source note
+    documents GitHub Copilot Max as a named subscription tier for individual users.
+    This is the first corpus entry to reference it, without defining its capabilities
+    or pricing relative to Pro+.
+  - **Individual plan access to CCA workflow-fix without apparent org admin gating**:
+    The May 18 announcement required org admin enablement (Business/Enterprise context).
+    The June 4 announcement's omission of that requirement for individual plans is the
+    first corpus evidence that CCA's "Fix with Copilot" feature may be self-service for
+    individual subscribers — pending verification against linked documentation.
+
+## Guide Impact
+
+- **Chapter 02 (Harness Engineering)**:
+  - Update the "Fix with Copilot" CCA invocation path (Path 4 in the taxonomy from
+    `docs-github-copilot-cca-fix-failing-actions.md`) to reflect the expanded tier
+    access. This path is no longer Business/Enterprise-only; as of June 4, it applies
+    to individual developers on Pro, Pro+, and Max. Revise any guidance that frames
+    this as an org-tier-only feature.
+  - Add a note that individual plan users (Pro/Pro+/Max) likely do not require org admin
+    enablement to access the feature, unlike Business/Enterprise users — creating a lower
+    onboarding barrier for individual practitioners. Flag this as pending verification.
+
+- **Chapter 05 (Team Adoption)**:
+  - Update individual plan adoption guidance: developers on Pro, Pro+, or Max now have
+    access to "Fix with Copilot" for failing Actions. Teams previously gated on Copilot
+    Business for this feature can now recommend it to individual plan subscribers.
+  - Revise any guidance that treats "Fix with Copilot" as exclusively org-tier. It is
+    now available at the individual subscription level, with potentially lower onboarding
+    friction (no admin enablement step for individual users).
+  - Note that "Copilot Max" exists as an individual plan tier eligible for this feature;
+    guide content describing the GitHub Copilot individual plan landscape should include
+    Max alongside Pro and Pro+.
+
+## Extraction Notes
+
+1. **Source is brief (~100 words)**: The June 4 changelog entry is a short tier-expansion
+   announcement. All claims are exhausted in five items above. The substantive new
+   content is Claim 1 (tier expansion). Claims 2, 3 restate May 18 verbatim; Claims 4,
+   5 derive from structural absences and naming in the June 4 text.
+
+2. **WebFetch verbatim reliability**: Two fetches were performed; quotes were consistent
+   across both. The body quotes for Claims 1–3 were returned inside quotation marks by
+   the second fetch, treated as verbatim. Claims 2 and 3 are further corroborated by
+   verbatim-matching the May 18 source note (same feature description reused). The
+   Assayer should spot-check Claim 1's tier names (Pro, Pro+, Max) against the live URL —
+   those are the structurally critical words differentiating the two changelog entries.
+
+3. **Admin prerequisite not verified for individual plans**: Claim 4 notes the absence
+   of the admin-enablement paragraph from the June 4 entry. This is plausibly intentional
+   (individual plans have no org admin) but is not confirmed by the linked docs. The
+   Assayer should fetch the "Starting GitHub Copilot sessions" documentation page linked
+   from the June 4 entry and check whether it includes an individual-plan-specific
+   enablement step.
+
+4. **"Copilot Max" not defined**: The June 4 entry names Max without defining it. No
+   existing corpus source note documents Copilot Max as an individual subscription tier.
+   Claim 5 flags this gap. A dedicated source note on Copilot Max plan details would be
+   needed to complete the individual plan tier picture.
+
+5. **No contradictions filed**: The June 4 announcement is purely additive. No prior
+   source note claims that Pro/Pro+/Max cannot access CCA workflow-fix. The May 18 note
+   documents Business/Enterprise access without excluding individual plans by name —
+   the absence of Pro/Pro+/Max from the May 18 announcement was a scope omission, not
+   an explicit exclusion. No contradiction issue required.


### PR DESCRIPTION
Source note extracted by the Miner agent for #1110.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.
