### PR TITLE
source: docs-github-copilot-aw-github-token-auth (#1155)

### DIFF
--- a/registry/sources.json
+++ b/registry/sources.json
@@ -1,5 +1,18 @@
 {
   "sources": {
+    "docs-github-copilot-aw-github-token-auth": {
+      "slug": "docs-github-copilot-aw-github-token-auth",
+      "title": "Agentic workflows no longer need a personal access token",
+      "source_url": "https://github.blog/changelog/2026-06-11-agentic-workflows-no-longer-need-a-personal-access-token",
+      "source_type": "docs",
+      "author": "GitHub (official changelog)",
+      "date_published": "2026-06-11",
+      "date_extracted": "2026-06-12",
+      "issue": "#1155",
+      "file": "source-notes/docs-github-copilot-aw-github-token-auth.md",
+      "confidence_overall": "settled",
+      "status": "current"
+    },
     "blog-cursor-bugbot-updates-june-2026": {
       "slug": "blog-cursor-bugbot-updates-june-2026",
       "title": "Bugbot is now over 3x faster, 22% cheaper, and finds 10% more bugs",

--- a/source-notes/docs-github-copilot-aw-github-token-auth.md
+++ b/source-notes/docs-github-copilot-aw-github-token-auth.md
@@ -1,0 +1,311 @@
+---
+source_url: https://github.blog/changelog/2026-06-11-agentic-workflows-no-longer-need-a-personal-access-token
+source_type: docs
+title: "Agentic workflows no longer need a personal access token"
+author: GitHub (official changelog)
+date_published: 2026-06-11
+date_extracted: 2026-06-12
+last_checked: 2026-06-12
+status: current
+confidence_overall: settled
+issue: "#1155"
+---
+
+# Agentic Workflows No Longer Need a Personal Access Token
+
+> GitHub's June 11, 2026 changelog announces that agentic workflows can now authenticate
+> using the built-in GitHub Actions `GITHUB_TOKEN` instead of requiring a personal access
+> token — eliminating a key operational burden for teams deploying agentic workflows at scale
+> and shifting AI credit billing to the organization when used in org-owned repositories.
+
+## Source Context
+
+- **Type**: docs (GitHub official product changelog, June 11, 2026; approximately 300 words)
+- **Author credibility**: GitHub engineering team announcing a production platform change.
+  Authoritative for: the new authentication capability, the new billing behavior in
+  organization-owned repositories, the configuration steps (permissions frontmatter change
+  + recompile), the cost management options, and plan availability. First-party announcement;
+  no reason to doubt the feature exists as described.
+- **Scope**: The elimination of the PAT requirement for agentic workflow execution; org
+  billing behavior when using GITHUB_TOKEN; configuration steps for enabling the feature;
+  cost management options for org billing; plan availability. Does NOT cover: whether
+  specific safe outputs (such as `assign-to-agent`) still require a PAT for their own
+  elevated write operations, migration steps from existing PAT-based setups, rate limit or
+  quota differences between PAT and GITHUB_TOKEN authentication, the exact scope of write
+  permissions GITHUB_TOKEN carries under `copilot-requests: write`, or security implications
+  beyond the stated operational benefits.
+
+## Extracted Claims
+
+### Claim 1: Agentic workflows can now authenticate using the built-in GitHub Actions `GITHUB_TOKEN`, eliminating the PAT requirement for workflow execution
+
+- **Evidence**: Official GitHub changelog announcement with explicit statement.
+- **Confidence**: settled (first-party announcement of a production feature change)
+- **Quote**: "You can now use GitHub Agentic Workflows with GitHub Actions's built-in
+  `GITHUB_TOKEN`."
+- **Our assessment**: This is a significant reduction in deployment friction for teams
+  setting up agentic workflows. Previously, each team had to provision, scope, store, and
+  rotate a fine-grained PAT — a coordination overhead that may have blocked adoption in
+  organizations with strict PAT policies or administrative delays. With `GITHUB_TOKEN`,
+  authentication is automatic and handled by the Actions runner, the same model used by
+  virtually all other GitHub Actions workflows. This removes an exception case that
+  previously complicated the "how do I get started" story in Ch02. The scope of this
+  change relative to specific safe outputs (e.g., `assign-to-agent`) is unresolved —
+  see contradiction issue #1161.
+
+### Claim 2: The PAT elimination removes operational and security risks associated with managing long-lived credentials at scale
+
+- **Evidence**: Stated by GitHub in the changelog as the motivation for the change;
+  corroborated by general security principles around ephemeral vs. long-lived credentials.
+- **Confidence**: settled (first-party security claim from the announcement)
+- **Quote**: (no direct quote; see paraphrase in Our assessment)
+- **Our assessment**: Long-lived PATs carry lifecycle risk: they can be over-scoped,
+  forgotten, leaked, or silently expire. At organizational scale (many repositories,
+  many workflows), PAT management becomes a standing operational burden and a compliance
+  audit surface. The shift to `GITHUB_TOKEN` eliminates this class of risk because the
+  token is ephemeral (scoped to the workflow run), automatically rotated by GitHub
+  Actions, and constrained by the workflow's declared permissions. This aligns with the
+  "no write access by default" principle in `docs-ghaw-how-they-work.md` Claim 4 —
+  least-privilege by default, explicit escalation only where needed.
+
+### Claim 3: When `GITHUB_TOKEN` is used in an organization-owned repository, AI credits are billed directly to the organization, not to individual users
+
+- **Evidence**: Official changelog states this billing behavior directly, with explicit
+  mention of the "organization-owned repository" condition as a prerequisite.
+- **Confidence**: settled
+- **Quote**: "When you use the Actions token in an agentic workflow running in an
+  organization-owned repository, AI credits consumed by your agentic workflow are billed
+  directly to the organization."
+- **Our assessment**: This is a significant billing model shift for enterprise users.
+  Previously, when individuals ran agentic workflows using their own PATs, AI credits
+  consumed by those workflows drew from their individual per-user AI credit allotments.
+  With the GITHUB_TOKEN approach, the cost center moves to the organization. This has
+  two effects: (1) individual users are no longer responsible for costs incurred by
+  org-owned agentic workflows; (2) organizations must manage AI credit consumption as an
+  organizational expense. This is directly connected to
+  `docs-github-copilot-code-review-actions-billing.md` Claim 1, which documented a
+  similar org-level billing shift for Copilot code review — the pattern of consolidating
+  Copilot AI costs at the organizational level is consistent across features.
+
+### Claim 4: Enabling org billing requires adding `copilot-requests: write` to the workflow's permissions frontmatter and recompiling the lockfile
+
+- **Evidence**: Official changelog with specific, explicit configuration steps.
+- **Confidence**: settled (exact configuration steps provided in first-party announcement)
+- **Quote**: "You can configure agentic workflows to bill directly to the organization by
+  adding `copilot-requests: write` to the `permissions` section in the frontmatter of
+  your agentic workflow markdown file, then compiling and pushing your updated lockfile."
+- **Our assessment**: The configuration follows the established gh-aw compilation model
+  (`docs-ghaw-how-they-work.md` Claim 7): edit the `.md` source, compile to `.lock.yml`,
+  push both. The `copilot-requests: write` permission is a new frontmatter field —
+  practitioners converting from PAT-based workflows must add it and recompile. Omitting
+  it would likely cause the workflow to fail authentication under the new GITHUB_TOKEN
+  model. For Ch02: add `copilot-requests: write` to the permissions checklist for
+  agentic workflow setup.
+
+### Claim 5: The "Allow use of Copilot CLI billed to the organization" org policy must be enabled as a prerequisite (enabled by default for orgs with an existing Copilot CLI policy)
+
+- **Evidence**: Mentioned in the changelog as a prerequisite; stated to be automatically
+  enabled for organizations that already have a Copilot CLI policy.
+- **Confidence**: settled (first-party prerequisite stated in changelog)
+- **Quote**: (no direct verbatim quote obtained for the exact policy name wording)
+- **Our assessment**: For teams already using the Copilot CLI policy, this prerequisite is
+  met automatically with no admin action required. For teams newly adopting agentic workflows
+  without a prior Copilot CLI policy, enabling the policy is an administrative step requiring
+  GitHub org-admin access. This is an org-level gate, not a per-repository setting — a single
+  enablement covers all repositories in the org. For Ch05: include this org-policy prerequisite
+  in the enterprise onboarding checklist.
+
+### Claim 6: The Agentic Workflows CLI must be upgraded to its latest version before using the new feature
+
+- **Evidence**: Official changelog specifies CLI upgrade as a prerequisite with the exact
+  upgrade command.
+- **Confidence**: settled (first-party prerequisite with explicit command)
+- **Quote**: "Use `$ gh extension upgrade aw` to upgrade."
+- **Our assessment**: An explicit CLI upgrade step is the standard pattern for new gh-aw
+  features. Teams with automated dependency management should add `gh extension upgrade aw`
+  to their CI or onboarding scripts. This is a low-friction step but a blocking prerequisite
+  — the new authentication path will not be available on older CLI versions.
+
+### Claim 7: When AI credits are billed to the organization, user-level inference budgets no longer apply; cost management is handled via org-level cost centers and per-workflow-run caps
+
+- **Evidence**: Official changelog, which notes that user-level budgets do not apply and
+  describes two org-level cost management mechanisms.
+- **Confidence**: settled
+- **Quote**: "Use the cost management tools in GitHub Agentic Workflows to monitor, manage,
+  and cap token usage per agentic workflow run."
+- **Our assessment**: This is the management mechanism that compensates for moving off
+  individual user budgets. Without per-user budgets as a natural spending ceiling, org-level
+  cost visibility and controls are critical — a runaway agentic workflow could consume
+  unbounded AI credits against the organization's account. The two stated mechanisms (cost
+  centers and per-workflow-run caps) provide both aggregate visibility and per-workflow
+  enforcement. For Ch02: document cost management configuration as a required parallel step
+  alongside the `copilot-requests: write` permission change — enabling org billing without
+  configuring cost controls leaves spend ungoverned.
+
+### Claim 8: `GITHUB_TOKEN` authentication for agentic workflows is available across all Copilot plan tiers
+
+- **Evidence**: Official changelog explicitly lists all plan tiers.
+- **Confidence**: settled
+- **Quote**: "This feature is available for all Copilot plans: Copilot Free, Copilot Pro,
+  Copilot Pro+, Copilot Business, and Copilot Enterprise."
+- **Our assessment**: Universal availability across plan tiers means this is the standard
+  authentication model going forward, not an enterprise-only feature. Individual developers
+  on Copilot Free or Pro plans can also use GITHUB_TOKEN for their personal agentic
+  workflows, with AI credits billed to the organization when running in org-owned
+  repositories. For personal repositories, billing behavior is likely individual (the
+  changelog specifies "organization-owned repository" as the condition for org billing,
+  implying personal repositories follow a different path).
+
+## Concrete Artifacts
+
+### Frontmatter — Adding `copilot-requests: write` Permission
+
+```yaml
+# Add to the permissions section of your agentic workflow .md file
+# Source: github.blog/changelog/2026-06-11-agentic-workflows-no-longer-need-a-personal-access-token
+
+---
+# ... existing frontmatter (triggers, tools, etc.) ...
+permissions:
+  copilot-requests: write   # Enables GITHUB_TOKEN authentication + org billing
+  # ... other permissions (e.g., contents: read) ...
+---
+```
+
+*After adding: run `gh aw compile` and push the updated `.lock.yml`.*
+
+### CLI Upgrade Command
+
+```bash
+# Upgrade the Agentic Workflows CLI before using GITHUB_TOKEN authentication
+# Source: github.blog/changelog/2026-06-11-agentic-workflows-no-longer-need-a-personal-access-token
+$ gh extension upgrade aw
+```
+
+### Migration Checklist (PAT → GITHUB_TOKEN)
+
+```
+Prerequisites for GITHUB_TOKEN authentication in agentic workflows:
+
+1. Org policy: "Allow use of Copilot CLI billed to the organization" must be enabled
+   → Enabled by default for orgs already having a Copilot CLI policy
+   → Otherwise requires org-admin action
+
+2. CLI version: Run `gh extension upgrade aw`
+
+3. Workflow permissions: Add `copilot-requests: write` to the `permissions` section
+   in the agentic workflow .md frontmatter
+
+4. Recompile: Run `gh aw compile` and push the updated .lock.yml
+
+5. Cost management: Configure cost centers or per-workflow-run caps
+   → User-level inference budgets no longer apply for org-owned repos
+   → Use GitHub Agentic Workflows cost management tools
+
+Note: Unclear whether assign-to-agent safe output still requires GH_AW_AGENT_TOKEN
+(fine-grained PAT) for its specific write operations — see contradiction #1161.
+```
+
+## Cross-References
+
+- **Contradicts**: `docs-ghaw-assign-to-copilot.md` Claim 7 — "Authentication requires a
+  fine-grained Personal Access Token (PAT); the default `GITHUB_TOKEN` lacks the necessary
+  permissions, and GitHub App tokens are explicitly not supported." This new changelog says
+  `GITHUB_TOKEN` is now sufficient for agentic workflows. The scope of the contradiction
+  is unresolved: the new GITHUB_TOKEN support may cover general workflow Copilot API
+  authentication but not the `assign-to-agent` safe output's specific write operations
+  (assigning Copilot to issues/PRs). **Contradiction issue filed: #1161.**
+
+- **Corroborates**:
+  - `docs-ghaw-how-they-work.md` Claim 4 ("Workflows run with minimal permissions — no
+    write access by default"): The `GITHUB_TOKEN` approach strengthens this principle —
+    ephemeral runner tokens constrained by declared permissions are a tighter fit with
+    the least-privilege design than long-lived PATs. GITHUB_TOKEN-based workflows now
+    match the default Actions security model.
+  - `docs-ghaw-rate-limiting-controls.md` Claim 2 (bot non-triggering protection does NOT
+    apply when using PAT instead of GITHUB_TOKEN): With PATs no longer required for general
+    workflow execution, teams switching to GITHUB_TOKEN will now benefit from the bot
+    non-triggering infinite-loop protection that PAT-based workflows previously bypassed.
+    This is a concrete security improvement that falls out of the authentication change.
+  - `docs-github-copilot-code-review-actions-billing.md` Claim 1 (Copilot code review
+    billing shifts to org-level): Both announcements move GitHub Copilot AI costs from
+    per-user to org billing. The pattern is consistent: GitHub is consolidating AI spend
+    management at the organizational level across all Copilot-driven features.
+
+- **Extends**:
+  - `docs-ghaw-assign-to-copilot.md` Claim 8 (`GH_AW_AGENT_TOKEN` magic secret fallback):
+    With GITHUB_TOKEN now handling the primary agentic workflow authentication, the
+    `GH_AW_AGENT_TOKEN` secret may become scoped only to specific safe outputs requiring
+    elevated permissions beyond what GITHUB_TOKEN provides. The relationship between the
+    new `copilot-requests: write` permission and the existing `GH_AW_AGENT_TOKEN`
+    convention needs clarification pending contradiction resolution #1161.
+  - `docs-ghaw-how-they-work.md` Claim 7 (`.md` → `.lock.yml` compilation model): The
+    `copilot-requests: write` configuration change follows the established compilation
+    workflow exactly — edit `.md`, run `gh aw compile`, push updated `.lock.yml`. No
+    special compilation path is introduced.
+  - `docs-ghaw-cost-management.md` (if that note covers cost center and per-run cap
+    configuration): this changelog introduces `copilot-requests: write` as the trigger
+    that activates org-level cost management for agentic workflows.
+
+- **Novel**:
+  - **`copilot-requests: write` as a new permission field** (Claim 4): No prior corpus
+    note documents this specific permission field. It is the frontmatter mechanism that
+    simultaneously enables GITHUB_TOKEN-based authentication and org billing.
+  - **Org billing triggered by `GITHUB_TOKEN` usage in org repos** (Claim 3): Prior
+    corpus notes document billing for other Copilot features but not the specific
+    GITHUB_TOKEN → org billing link for agentic workflows.
+  - **User-level budgets no longer applying under org billing** (Claim 7): The condition
+    under which individual user AI credit budgets cease to govern agentic workflow spend
+    is not documented elsewhere in the corpus.
+  - **Bot non-triggering protection now active by default** (derived from Claims 1 + 2 +
+    `docs-ghaw-rate-limiting-controls.md` Claim 2): The security implication that
+    switching to GITHUB_TOKEN restores the bot non-triggering loop protection is not
+    stated in this source, but follows directly from combining this announcement with the
+    rate-limiting controls reference — worth surfacing in Ch03.
+
+## Guide Impact
+
+- **Chapter 02 §Harness Engineering**: Update the agentic workflow setup checklist to
+  replace "provision fine-grained PAT → store as `GH_AW_AGENT_TOKEN`" with "add
+  `copilot-requests: write` to frontmatter permissions → run `gh aw compile` → push
+  `.lock.yml`." This simplifies onboarding significantly. Document the PAT-based path as
+  a legacy fallback for safe outputs that may still require elevated permissions (pending
+  resolution of contradiction #1161). Add cost management configuration as a required
+  parallel step when enabling org billing.
+
+- **Chapter 03 §Safety and Verification**: Update the PAT security risk discussion to
+  reflect that GITHUB_TOKEN authentication eliminates the long-lived credential attack
+  surface for agentic workflows. Add the bot non-triggering loop protection point: teams
+  that previously used PAT-based write operations lost that protection (per
+  `docs-ghaw-rate-limiting-controls.md` Claim 2); teams migrating to GITHUB_TOKEN regain
+  it.
+
+- **Chapter 05 §Team Adoption / Enterprise Governance**: Add the "Allow use of Copilot
+  CLI billed to the organization" policy as a one-time org-admin prerequisite. Update PAT
+  provisioning sections — formerly required for all agentic workflows, PAT provisioning
+  is now optional or scoped only to specific safe outputs. Add AI credit org billing as a
+  cost model option, noting that it requires configuring cost centers or per-run caps to
+  govern spend.
+
+## Extraction Notes
+
+1. **Verbatim content limited by WebFetch rendering**: The source is a GitHub changelog
+   page (approximately 300 words). Three separate WebFetch requests were made with
+   progressively more explicit verbatim-extraction instructions. The WebFetch AI layer
+   consistently returned summarized rather than fully verbatim content. Six verbatim
+   quotes were confirmed across multiple independent fetches; all other claims are marked
+   `(no direct quote; see paraphrase in Our assessment)` per MINER.md §2a.
+
+2. **Scope uncertainty for `assign-to-agent`**: The changelog does not explicitly clarify
+   whether the new GITHUB_TOKEN support covers the `assign-to-agent` safe output's specific
+   authentication requirements (assigning Copilot coding agent to issues/PRs) or only the
+   general Copilot API request authentication (`copilot-requests: write`). Contradiction
+   issue #1161 captures this ambiguity for human review.
+
+3. **Contradiction filed before PR**: Per MINER.md §4a, the contradiction with
+   `docs-ghaw-assign-to-copilot.md` Claim 7 was filed as issue #1161 before this PR
+   was opened.
+
+4. **`docs-ghaw-cost-management.md` not read**: That note likely covers cost center
+   configuration in detail; cross-reference added speculatively. Verify against the
+   actual note before the Smith synthesizes Ch02 cost management guidance.


### PR DESCRIPTION
Source note extracted by the Miner agent for #1155.

See `agents/MINER.md` for the extraction rubric and the
Assayer review standards this PR will be checked against.
The source issue stays open until merge so the Assayer
verdict and any rework are tracked there.

## What was extracted

**Source**: GitHub official changelog (June 11, 2026) — `github.blog/changelog/2026-06-11-agentic-workflows-no-longer-need-a-personal-access-token`

**8 claims extracted**, including:
- GITHUB_TOKEN now sufficient for agentic workflow authentication (Claim 1)
- PAT elimination removes long-lived credential risks at scale (Claim 2)
- AI credits billed to org when using GITHUB_TOKEN in org-owned repos (Claim 3)
- `copilot-requests: write` frontmatter permission + recompile required (Claim 4)
- Org policy prerequisite (Claim 5) and CLI upgrade (`gh extension upgrade aw`) required (Claim 6)
- Cost management via cost centers + per-run caps when user budgets don't apply (Claim 7)
- Available across all Copilot plan tiers (Claim 8)

**Contradiction filed**: `docs-ghaw-assign-to-copilot.md` Claim 7 (May 2026: PAT required) vs. this changelog (June 2026: GITHUB_TOKEN sufficient) → **issue #1161**

**Cross-references verified**: `docs-ghaw-how-they-work.md` Claims 4 and 7, `docs-ghaw-rate-limiting-controls.md` Claim 2, `docs-github-copilot-code-review-actions-billing.md` Claim 1, `docs-ghaw-assign-to-copilot.md` Claims 7 and 8.
